### PR TITLE
feat(home): kick off content and component set up for the landing page

### DIFF
--- a/assets/pages/cv.json
+++ b/assets/pages/cv.json
@@ -4,16 +4,210 @@
   "slug": "cv",
   "contents": [
     {
-      "tagName": "h1",
-      "text": "CV!"
+      "tagName": "section",
+      "id": "intro",
+      "content": [
+        {
+          "tagName": "h1",
+          "content": "Curriculum Vitae"
+        },
+        {
+          "tagName": "h2",
+          "content": "My work experience and qualifications from 2001 to present"
+        }
+      ]
     },
     {
-      "tagName": "h2",
-      "text": "My work experience over the last 15 years."
-    },
-    {
-      "tagName": "p",
-      "text": "Hint. I have lots."
+      "tagName": "section",
+      "id": "work-experience",
+      "content": [
+        {
+          "tagName": "jobs",
+          "content": [
+            {
+              "company": "Travelport Digital",
+              "location": "Dublin, Ireland",
+              "role": "Senior front-end engineer",
+              "startDate": "2020-01-06",
+              "tasks": [
+                "Migrated client project from AngularJS to ReactJS with TypeScript.",
+                "Replaced LESS/SASS with syled-components (CSS in JS).",
+                "Planned and implemented strategy to recover test coverage.",
+                "Provided consultation to implement third party features seamlessly in client application."
+              ],
+              "topics": []
+            },
+            {
+              "company": "heycar",
+              "endDate": "2020-12-31",
+              "location": "Berlin, Germany",
+              "role": "Senior front-end engineer",
+              "startDate": "2017-08-08",
+              "tasks": [
+                "Created and maintained a marketplace and CRM for a used car platform.",
+                "Managed technical debt for projects and maintained 100% test coverage.",
+                "Platforms created using ReactJS with Redux for state management and Jest for testing.",
+                "Mentored junior engineers, reviewed CVs and interviewed candidates."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Freelance Software Engineer",
+              "endDate": "2018-01-01",
+              "location": "Berlin, Germany",
+              "role": "Senior full-stack engineer",
+              "startDate": "2014-12-01",
+              "tasks": [
+                "Created and maintained community websites for cloud based service providers.",
+                "Set up continuous integration (testing and deployment) for projects.",
+                "Made regular contributions to popular Open-source projects and started two of my own.",
+                "Created several portfolio websites using MeteorJS and then GoHugo."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Things I Like GMBH",
+              "endDate": "2014-11-31",
+              "location": "Berlin, Germany",
+              "role": "Senior full-stack engineer",
+              "startDate": "2014-06-01",
+              "tasks": [
+                "Implemented a new website for the Monoqi B2B platform to facilitate communication and sales between designers and resellers.",
+                "Improved purchase flows and address verification for the Monoqi B2C platform.",
+                "Created new tools to improve front end development workflow for the team.",
+                "Authored email templates for both platforms to increase conversion rates."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Axel Springer Ideas",
+              "endDate": "2014-04-31",
+              "location": "Berlin, Germany",
+              "role": "Senior front-end engineer",
+              "startDate": "2013-10-10",
+              "tasks": [
+                "Created a web application using the Meteor Javascript framework for an Axel Springer Ideas funded startup TunedIn to deliver native-like performance.",
+                "Main features include a TV Guide and participation stream, both of which update in real time.",
+                "Wrote unit and acceptance tests to ensure the product was stable and robust throughout each sprint.",
+                "Supported the product owner and marketing team in creating the company website and marketing emails."
+              ],
+              "topics": []
+            },
+            {
+              "company": "iQContent Ltd",
+              "endDate": "2013-09-15",
+              "location": "Dublin, Ireland",
+              "role": "Senior full-stack engineer (contract)",
+              "startDate": "2013-03-12",
+              "tasks": [
+                "Created a knowledge based information portal (secure document sharing, retrieval and storage) for a large telecomms organisation in PHP.",
+                "Optimised customer login/registration flow and integrated this with other CRM tools (Salesforce, Eloqua).",
+                "Integrated the Compass SCSS framework and optimised HTML templates to improve SEO performance.",
+                "Developed HTML templates for the internal corporate IT intranet and assisted in integrating them to Microsoft Sharepoint."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Maithu IT Solutions",
+              "endDate": "2013-03-09",
+              "location": "Dublin, Ireland",
+              "role": "Technical lead",
+              "startDate": "2012-01-12",
+              "tasks": [
+                "Drove the development of multiple mobile applications.",
+                "Developed an electronic programming guide (EPG) in HTML5 for set top boxes, smart TVs and the web.",
+                "Overhauled the Irish Times News app (iOS, Android), integrating to their existing web infrastructure.",
+                "Responsible for client satisfaction by delivering quality products on time and within budget.",
+                "Responsible for reviewing CVs, creating recruitment exercises and interviewing candidates for development roles."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Paddy Power PLC",
+              "endDate": "2012-01-06",
+              "location": "Dublin, Ireland",
+              "role": "Senior full-stack engineer",
+              "startDate": "2010-03-08",
+              "tasks": [
+                "Maintained high performance websites under heavy server load.",
+                "Upgraded the in-house CMS for Paddy Power Games and Casino to enable targeted content delivery for different user groups.",
+                "Built a staff rostering and payroll processing system used by shop managers for all Paddy Power retail outlets.",
+                "Our scrum approach to development ensured timely delivery of product phases and stakeholders were kept up to date with development on large projects."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Freelance Software Engineer",
+              "endDate": "2010-03-01",
+              "location": "Dublin, Ireland",
+              "role": "Senior full-stack engineer",
+              "startDate": "2008-07-01",
+              "tasks": [
+                "Created several bespoke content managed websites for clients using hand-coded html and php.",
+                "Leveraged Twitter and Facebook APIs, to optimise the clients’ online offering.",
+                "Provided web content strategy guidance to clients.",
+                "Practiced excellent standards in web development to ensure organic SEO performance and accessibility.",
+                "Initiated, managed and maintained long-lasting professional client relationships."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Net a Porter",
+              "endDate": "2008-07-01",
+              "location": "London, UK",
+              "role": "Full stack engineer (Java)",
+              "startDate": "2007-06-01",
+              "tasks": [
+                "Redeveloped the HTML and CSS during a complete overhaul of the company website.",
+                "Created an internal WYSIWYG tool to author promotional emails and newsletter templates.",
+                "Designed and built the in house intranet portal, tying it into existing LDAP servers. This enabled seamless integration with existing user logins.",
+                "Provided ongoing maintenance to website product pages to optimise the eCommerce purchase flows."
+              ],
+              "topics": []
+            },
+            {
+              "company": "FindMyPast.com",
+              "endDate": "2007-06-01",
+              "location": "London, UK",
+              "role": "Full stack engineer (Java)",
+              "startDate": "2006-09-15",
+              "tasks": [
+                "Upgraded site standards compliancy in XHTML and CSS.",
+                "Coordinated internal knowledge sharing through regular web standards training.",
+                "Re-modeled html email templates for all marketing campaigns.",
+                "Provided ongoing maintenance and enhancements for the company website."
+              ],
+              "topics": []
+            },
+            {
+              "company": "AOL Technologies Ltd",
+              "endDate": "2006-06-31",
+              "location": "Dublin, Ireland",
+              "role": "Associate software engineer",
+              "startDate": "2005-07-01",
+              "tasks": [
+                "Created a web app to monitor RSS feeds from news providers.",
+                "Built an XSLT processor to populate XML feeds to databases.",
+                "Upgraded servers and software from HPUX to Linux and authored the associated technical documentation."
+              ],
+              "topics": []
+            },
+            {
+              "company": "Dublin City University",
+              "endDate": "2005-06-01",
+              "location": "Dublin, Ireland",
+              "role": "BSc. in Computer Applications (Honours)",
+              "startDate": "2001-09-26",
+              "tasks": [
+                "Modules include Java software development, Business process management, Computer Graphics, Database administration and the Software development life-cycle (waterfall).",
+                "Alcatel CIT, France: developed an error logging system for GSM cell towers (INTRA work placement).",
+                "Coded a mobile 2D game using J2ME (Final year project)."
+              ],
+              "topics": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/assets/pages/home.json
+++ b/assets/pages/home.json
@@ -4,28 +4,353 @@
   "slug": "home",
   "contents": [
     {
-      "tagName": "h1",
-      "text": "Hello!"
+      "tagName": "section",
+      "id": "intro",
+      "content": [
+        {
+          "tagName": "h1",
+          "content": "Hello! I'm Matt Finucane"
+        },
+        {
+          "tagName": "h2",
+          "content": "I am Dublin based front-end software engineer"
+        },
+        {
+          "tagName": "p",
+          "content": "I have 15 years of experience under my belt working on a wide variety of projects across multiple domains and in differnt workplace settings."
+        },
+        {
+          "tagName": "p",
+          "content": "I have worked on projects in-house, for agencies and as a freelancer in both capacities. I have worked from shared offices and remotely."
+        },
+        {
+          "tagName": "p",
+          "content": "My primary focus is on building single page applications in TypeScript that are performant, scalable and easy to maintain."
+        },
+        {
+          "tagName": "p",
+          "content": "Please feel free to take a look around this website, which showcases my skills and experience, and get in touch if you need anything :)"
+        }
+      ]
     },
     {
-      "tagName": "h2",
-      "text": "I am Dublin based front-end software engineer"
+      "tagName": "section",
+      "id": "skills",
+      "content": [
+        {
+          "tagName": "ul",
+          "content": [
+            {
+              "tagName": "li",
+              "content": "Effective communication skills; training, presentations, documentation and delegation."
+            },
+            {
+              "tagName": "li",
+              "content": "Practice and advocate the highest development standards."
+            },
+            {
+              "tagName": "li",
+              "content": "In-depth understanding of technologies across multiple domains."
+            },
+            {
+              "tagName": "li",
+              "content": "Strong analytical thinking and problem solving skills."
+            },
+            {
+              "tagName": "li",
+              "content": "Life-long learner with strong interest in continuous professional development."
+            }
+          ]
+        }
+      ]
     },
     {
-      "tagName": "p",
-      "text": "I have 15 years of experience under my belt working on a wide variety of projects across multiple domains and in differnt workplace settings."
+      "tagName": "section",
+      "id": "topics",
+      "content": [
+        {
+          "tagName": "topics",
+          "content": [
+            {
+              "category": "languages",
+              "description": "Typescript is a superset of Javascript created by Microsoft. It borrows from C# and features strong typing.",
+              "slug": "typescript",
+              "title": "TypeScript"
+            },
+            {
+              "category": "languages",
+              "description": "Javascript (ES) is a modern version of Javascript.",
+              "slug": "javascript-es",
+              "title": "Javascript (ES)"
+            },
+            {
+              "category": "languages",
+              "deprecated": "true",
+              "description": "PHP is a high level programming language commonly used in server-side web development.",
+              "slug": "php",
+              "title": "PHP"
+            },
+            {
+              "category": "languages",
+              "deprecated": "true",
+              "description": "Objective C is a superset of C created by Apple. It was used primarily in application development but has been superseded by Swift.",
+              "slug": "objective-c",
+              "title": "Objective C"
+            },
+            {
+              "category": "languages",
+              "deprecated": "true",
+              "description": "Python is a high level language known for its power and simplicity.",
+              "slug": "python",
+              "title": "Python"
+            },
+            {
+              "category": "languages",
+              "deprecated": "true",
+              "description": "C++ is a general purpose strongly-typed programming language used in application development.",
+              "slug": "cpp",
+              "title": "C++"
+            },
+            {
+              "category": "languages",
+              "deprecated": "true",
+              "description": "C# is a high level, general purpose, strongly-typed language created my Microsoft.",
+              "slug": "csharp",
+              "title": "C#"
+            },
+            {
+              "category": "frontend",
+              "description": "ReactJS is a front end library for creating components that make up a single page application.",
+              "slug": "reactjs",
+              "title": "ReactJS"
+            },
+            {
+              "category": "frontend",
+              "description": "Redux is a state management system used in web application development.",
+              "slug": "redux",
+              "title": "Redux"
+            },
+            {
+              "category": "frontend",
+              "description": "Styled components works with React and facilitates styling via CSS in JS.",
+              "slug": "styled-components",
+              "title": "Styled Components"
+            },
+            {
+              "category": "frontend",
+              "description": "Progressive web apps are those that work (even offline) on any standards compliant browser",
+              "slug": "pwa",
+              "title": "PWA"
+            },
+            {
+              "category": "frontend",
+              "description": "These act as CSS pre-processors and make it easier to manage styles for large, cross-browser applications.",
+              "slug": "scss-sass-less",
+              "title": "SCSS / SASS / LESS"
+            },
+            {
+              "category": "frontend",
+              "description": "CSS Grid is modern technique for laying out web pages.",
+              "slug": "css-grid",
+              "title": "CSS Grid"
+            },
+            {
+              "category": "frontend",
+              "description": "PolymerJS is a Javascript based web application framework built by Google, which leverages Web Components.",
+              "slug": "polymerjs",
+              "title": "PolymerJS"
+            },
+            {
+              "category": "frontend",
+              "description": "MeteorJS is one of the earliest full-stack web application frameworks and works with MongoDB both client and server side.",
+              "slug": "meteorjs",
+              "title": "MeteorJS"
+            },
+            {
+              "category": "frontend",
+              "description": "jQuery is a javascript library commonly used for cross-browser UI development, especially for non single-page applications.",
+              "slug": "jquery",
+              "title": "jQuery"
+            },
+            {
+              "category": "frontend",
+              "description": "Gulp / Grunt are used to manage and pacakge web applications and their dependencies. Both of these have been deprecated in favour of WebPack.",
+              "slug": "gulp-grunt",
+              "title": "Gulp / Grunt"
+            },
+            {
+              "category": "backend",
+              "description": "NodeJS is a Javascript server side run time.",
+              "slug": "nodejs",
+              "title": "NodeJS"
+            },
+            {
+              "category": "backend",
+              "description": "ExpressJS is a library used to create REST servers in NodeJS.",
+              "slug": "expressjs",
+              "title": "ExpressJS"
+            },
+            {
+              "category": "backend",
+              "description": "Docker is a tool that makes it easier to manage complex tools and environments, and ties each piece of infrastructure together (as containers) to form a working project.",
+              "slug": "docker",
+              "title": "Docker"
+            },
+            {
+              "category": "backend",
+              "description": "MongoDB is a document oriented database and Mongoose is a library for NodeJS that makes it easier to interact with it.",
+              "slug": "mongodb-mongoose",
+              "title": "MongoDB / Mongoose"
+            },
+            {
+              "category": "backend",
+              "description": "MySQL is an Open-source relational database management system.",
+              "slug": "mysql",
+              "title": "MySQL"
+            },
+            {
+              "category": "backend",
+              "description": "Nginx is a web server commonly used as a reverse-proxy for Javascript based web application development.",
+              "slug": "nginx",
+              "title": "Nginx"
+            },
+            {
+              "category": "backend",
+              "description": "Apache is an Open-source web server commonly used with PHP and MySQL.",
+              "slug": "apache-http-server",
+              "title": "Apache HTTP server"
+            },
+            {
+              "category": "backend",
+              "description": "Linux is a Open-source Unix-like operating system.",
+              "slug": "linux",
+              "title": "Linux"
+            },
+            {
+              "category": "tools",
+              "description": "Hugo is a static site generator that generates HTML from tempaltes combined with Markdown.",
+              "slug": "hugo",
+              "title": "Hugo"
+            },
+            {
+              "category": "tools",
+              "description": "Yarn and NPM are used to manage external dependencies for projects.",
+              "slug": "yarn-npm",
+              "title": "Yarn / NPM"
+            },
+            {
+              "category": "tools",
+              "description": "Webpack is a module bundler that delivers assets for a web application to the browser.",
+              "slug": "webpack",
+              "title": "Webpack"
+            },
+            {
+              "category": "tools",
+              "description": "Jest is a test runner commonly used in Typescript / Javascript projects, especially React.",
+              "slug": "jest",
+              "title": "Jest"
+            },
+            {
+              "category": "tools",
+              "description": "Mocha is a Javascript test runner.",
+              "slug": "mocha",
+              "title": "Mocha"
+            },
+            {
+              "category": "tools",
+              "description": "Chai is a helper library to facilitate test assertions.",
+              "slug": "chai",
+              "title": "Chai"
+            },
+            {
+              "category": "tools",
+              "description": "Sinon is a testing tool used to control tests by mocking function calls.",
+              "slug": "sinon",
+              "title": "SinonJS"
+            },
+            {
+              "category": "tools",
+              "description": "React testing library is used to test the behaviour of function components in React.",
+              "slug": "react-testing-library",
+              "title": "React Testing Library"
+            },
+            {
+              "category": "tools",
+              "description": "Enzyme is a testing library normally used for unit testing class based components in React.",
+              "slug": "enzyme",
+              "title": "Enzyme"
+            },
+            {
+              "category": "tools",
+              "description": "Supertest is a tool for integration testing.",
+              "slug": "supertest",
+              "title": "Supertest"
+            },
+            {
+              "category": "tools",
+              "description": "VSCode is a powerful and simple integrated development environment (IDE).",
+              "slug": "vscode",
+              "title": "VSCode"
+            },
+            {
+              "category": "tools",
+              "description": "WebStorm is an IDE used for front end web development, primarily with Javascript",
+              "slug": "webstorm",
+              "title": "WebStorm"
+            },
+            {
+              "category": "tools",
+              "description": "CircleCI is a tool that manages testing and deployment of web applications",
+              "slug": "circleci",
+              "title": "CircleCI"
+            },
+            {
+              "category": "tools",
+              "description": "Git is a widely used and very powerful source control management tool.",
+              "slug": "git",
+              "title": "Git"
+            },
+            {
+              "category": "tools",
+              "description": "ESLint is a code quality checker for Javascript and Typescript.",
+              "slug": "eslint",
+              "title": "ESLint"
+            },
+            {
+              "category": "tools",
+              "description": "stylelint is a tool used to check CSS rules for quality issues.",
+              "slug": "stylelint",
+              "title": "Stylelint"
+            },
+            {
+              "category": "tools",
+              "description": "Lighthouse is a tool created by Google that examines websites and scores them based on performance and accessibility.",
+              "slug": "lighthouse",
+              "title": "Lighthouse"
+            },
+            {
+              "category": "tools",
+              "description": "BabelJS re-compiles TypeScript / Javascript (ES) into a flavour of Javascript that older browsers can execute.",
+              "slug": "babeljs",
+              "title": "BabelJS"
+            }
+          ]
+        }
+      ]
     },
     {
-      "tagName": "p",
-      "text": "I have worked on projects in-house, for agencies and as a freelancer in both capacities. I have worked from shared offices and remotely."
-    },
-    {
-      "tagName": "p",
-      "text": "My primary focus is on building single page applications in TypeScript that are performant, scalable and easy to maintain."
-    },
-    {
-      "tagName": "p",
-      "text": "Please feel free to take a look around this website, which showcases my skills and experience, and get in touch if you need anything :)"
+      "tagName": "section",
+      "id": "outro",
+      "content": [
+        {
+          "tagName": "p",
+          "content": "If you are looking for somebody with strong technical and communication skills to take on a project at any stage in its lifecycle, I would be more than happy to work with you on that."
+        },
+        {
+          "tagName": "p",
+          "content": "Please feel free to checkout my [CV](/cv), which details my qualifications, skillsets and work experience. Here are some of the [projects](/projects) I have worked on."
+        }
+      ]
     }
   ]
 }

--- a/assets/pages/projects.json
+++ b/assets/pages/projects.json
@@ -4,16 +4,182 @@
   "slug": "projects",
   "contents": [
     {
-      "tagName": "h1",
-      "text": "Projets!"
+      "tagName": "section",
+      "id": "intro",
+      "content": [
+        {
+          "tagName": "h1",
+          "content": "Selected projects"
+        },
+        {
+          "tagName": "h2",
+          "content": "Some selected projects from my portfolio"
+        }
+      ]
     },
     {
-      "tagName": "h2",
-      "text": "Some of the things I work on in my spare time."
-    },
-    {
-      "tagName": "p",
-      "text": "I work on a lot of projects"
+      "tagName": "section",
+      "id": "projects",
+      "content": [
+        {
+          "tagName": "projects",
+          "content": [
+            {
+              "description": "Personal portfolio website.",
+              "releaseDate": "2020-05-15",
+              "slug": "mattfinucane",
+              "title": "Matt Finucane",
+              "topics": [
+                "typescript",
+                "reactjs",
+                "redux",
+                "styled-components",
+                "nodejs",
+                "expressjs",
+                "yarn-npm",
+                "webpack",
+                "vscode",
+                "jest",
+                "react-testing-library",
+                "eslint",
+                "stylelint",
+                "babeljs",
+                "lighthouse"
+              ]
+            },
+            {
+              "description": "High quality used car platform.",
+              "releaseDate": "2017-10-05",
+              "slug": "heycar",
+              "title": "hey.car",
+              "topics": [
+                "javascript-es",
+                "reactjs",
+                "redux",
+                "styled-components",
+                "scss-sass-less",
+                "nodejs",
+                "expressjs",
+                "yarn-npm",
+                "webpack",
+                "vscode",
+                "jest",
+                "enzyme",
+                "eslint",
+                "stylelint",
+                "babeljs"
+              ],
+              "url": "https://hey.car"
+            },
+            {
+              "description": "Photography portfolio website.",
+              "releaseDate": "2017-07-01",
+              "slug": "cinematt",
+              "title": "Cinematt",
+              "topics": [
+                "javascript-es",
+                "scss-sass-less",
+                "css-grid",
+                "nodejs",
+                "docker",
+                "nginx",
+                "hugo",
+                "yarn-npm",
+                "webpack",
+                "webstorm",
+                "circleci"
+              ],
+              "url": "https://cinematt.photography"
+            },
+            {
+              "description": "Personal portfolio wesite (static) which was released in 2017. It has been replaced and is now archived.",
+              "releaseDate": "2017-04-01",
+              "slug": "personal-portfolio-static",
+              "title": "Personal portfolio (static)",
+              "topics": [
+                "javascript-es",
+                "scss-sass-less",
+                "nodejs",
+                "docker",
+                "nginx",
+                "hugo",
+                "yarn-npm",
+                "webpack",
+                "webstorm",
+                "circleci"
+              ],
+              "url": "https://github.com/matfin/mattfinucane.com"
+            },
+            {
+              "description": "StackPointCloud.com community portal for users.",
+              "releaseDate": "2016-03-01",
+              "slug": "stackpointcloud-community",
+              "title": "StackPointCloud Comunity",
+              "topics": [
+                "javascript-es",
+                "scss-sass-less",
+                "polymerjs",
+                "gulp-grunt",
+                "nodejs",
+                "expressjs",
+                "docker",
+                "mongodb-mongoose",
+                "nginx",
+                "yarn-npm",
+                "webstorm",
+                "mocha",
+                "sinon",
+                "supertest",
+                "circleci"
+              ]
+            },
+            {
+              "description": "Back end infrastructure for an interactive Facebook Messenger chat bot curated by ARD-Tageschau",
+              "releaseDate": "2017-03-01",
+              "slug": "novi-chatbot",
+              "title": "Novi Chatbot",
+              "topics": [
+                "javascript-es",
+                "gulp-grunt",
+                "nodejs",
+                "expressjs",
+                "docker",
+                "yarn-npm",
+                "webstorm",
+                "mocha",
+                "sinon"
+              ],
+              "url": "https://www.tagesschau.de/messenger/"
+            },
+            {
+              "description": "ProfitBricks.com community portal contains setup guides and other help articles for system administration.",
+              "releaseDate": "2016-09-01",
+              "slug": "profitbricks-community",
+              "title": "ProfitBricks Comunity",
+              "topics": [
+                "javascript-es",
+                "python",
+                "php"
+              ]
+            },
+            {
+              "description": "Package created to bring headless CMS content into a Meteor project.",
+              "releaseDate": "2015-08-15",
+              "slug": "meteor-contentful",
+              "title": "Meteor Contentful",
+              "topics": [
+                "javascript-es",
+                "meteor",
+                "mocha",
+                "chai",
+                "sinon",
+                "expressjs"
+              ],
+              "url": "https://atmospherejs.com/matfin/meteor-contentful"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/app/components/contentItem/ContentItem.css.tsx
+++ b/src/app/components/contentItem/ContentItem.css.tsx
@@ -1,0 +1,56 @@
+import styled, { css } from 'styled-components';
+import {
+  fontSizes,
+  letterSpacing,
+  lineHeight,
+} from 'app/styles';
+import { Position } from 'app/components/position/Position';
+import { Project } from 'app/components/project/Project';
+import { Topic } from 'app/components/topic/Topic';
+
+const defaultText = css`
+  font-size: ${fontSizes.text}px;
+  letter-spacing: ${letterSpacing.text}px;
+  line-height: ${lineHeight.text}px;
+`;
+
+export const SectionSt = styled.section`
+  display: block;
+`;
+
+export const HeadingSt = styled.h1`
+  font-size: ${fontSizes.heading}px;
+  letter-spacing: ${letterSpacing.heading}px;
+  line-height: ${lineHeight.heading}px;
+`;
+
+export const SubHeadingSt = styled.h2`
+  font-size: ${fontSizes.subheading}px;
+  letter-spacing: ${letterSpacing.subheading}px;
+  line-height: ${lineHeight.subheading}px;
+`;
+
+export const ParagraphSt = styled.p`
+  ${defaultText};
+`;
+
+export const ListItemSt = styled.li`
+  ${defaultText};
+`;
+
+export const ListSt = styled.ul`
+  list-style: none;
+`;
+
+export const TopicSt = styled(Topic)`
+  background-color: red;
+`;
+
+export const PositionSt = styled(Position)`
+  background-color: green;
+`;
+
+export const ProjectSt = styled(Project)`
+  background-color: blue;
+`;
+

--- a/src/app/components/contentItem/ContentItem.spec.tsx
+++ b/src/app/components/contentItem/ContentItem.spec.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IContentItem } from 'common/interfaces';
+import { ContentItem, IProps } from './ContentItem';
+import { ProjectSt } from '../project/Project.css';
+
+describe('ContentItem tests', () => {
+  it('renders the component', () => {
+    const { container } = render(
+      <ContentItem
+        tagName="p"
+        content="This is a test"
+      />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('This is a test')).toBeTruthy();
+  });
+
+  describe('rendering standard html tags', () => {
+    it('renders a section', () => {
+      const { container } = render(
+        <ContentItem
+          tagName="section"
+          content="This is a section"
+        />
+      );
+
+      expect(container.querySelector('section')).toBeTruthy();
+      expect(screen.getByText('This is a section')).toBeTruthy();
+    });
+
+    it('renders a heading', () => {
+      const { container } = render(
+        <ContentItem
+          tagName="h1"
+          content="This is a heading"
+        />
+      );
+
+      expect(container.querySelector('h1')).toBeTruthy();
+      expect(screen.getByText('This is a heading')).toBeTruthy();
+    });
+
+    it('renders a subheading', () => {
+      const { container } = render(
+        <ContentItem
+          tagName="h2"
+          content="This is a subheading"
+        />
+      );
+
+      expect(container.querySelector('h2')).toBeTruthy();
+      expect(screen.getByText('This is a subheading')).toBeTruthy();
+    });
+
+    it('renders a paragraph', () => {
+      const { container } = render(
+        <ContentItem
+          tagName="p"
+          content="This is a paragraph"
+        />
+      );
+
+      expect(container.querySelector('p')).toBeTruthy();
+      expect(screen.getByText('This is a paragraph')).toBeTruthy();
+    });
+
+    it('renders a list with items', () => {
+      const props: IContentItem = {
+        tagName: 'ul',
+        content: [
+          { tagName: 'li', content: 'First' },
+          { tagName: 'li', content: 'Second' },
+          { tagName: 'li', content: 'Third' },
+        ] as any
+      };
+      const { container } = render(
+        <ContentItem {...props} />
+      );
+
+      expect(container.querySelector('ul')).toBeTruthy();
+      expect(container.querySelectorAll('li')).toHaveLength(3);
+      expect(screen.getByText('First')).toBeTruthy();
+      expect(screen.getByText('Second')).toBeTruthy();
+      expect(screen.getByText('Third')).toBeTruthy();
+    });
+
+    it('renders a span the tag is not recognised', () => {
+      const props: IContentItem = {
+        tagName: 'unknown',
+        content: 'Test content'
+      };
+      const { container } = render(
+        <ContentItem {...props} />
+      );
+
+      expect(container.querySelector('span')).toBeTruthy();
+      expect(screen.getByText('Test content')).toBeTruthy();
+    });
+  });
+
+  it('renders a list of topics', () => {
+    const props: IContentItem = {
+      tagName: 'topics',
+      content: [
+        {
+          category: "test",
+          description: "Test description",
+          slug: "test",
+          title: "Test"
+        },
+        {
+          category: "test",
+          description: "Another test description",
+          slug: "another-test",
+          title: "Another test"
+        }
+      ] as any
+    };
+    const { container } = render(
+      <ContentItem {...props} />
+    );
+
+    expect(container.querySelector('ul')).toBeTruthy();
+    expect(container.querySelectorAll('span')).toHaveLength(2);
+    expect(screen.getByText('Test')).toBeTruthy();
+    expect(screen.getByText('Another test')).toBeTruthy();
+  });
+
+  it('renders a job position', () => {
+    const props: IContentItem = {
+      tagName: 'jobs',
+      content: [
+        {
+          company: 'Test Company',
+          location: 'Test, Location',
+          role: 'Test role',
+          startDate: "2020-01-06",
+          tasks: [
+            'Task one',
+            'Task two',
+          ],
+          topics: []
+        }
+      ] as any
+    };
+    const { container } = render(
+      <ContentItem {...props} />
+    );
+
+    expect(container.querySelector('section')).toBeTruthy();
+    expect(container.querySelectorAll('div')).toHaveLength(1);
+    expect(screen.getByText('Test Company')).toBeTruthy();
+    expect(screen.getByText('Test role / Test, Location')).toBeTruthy();
+  });
+
+  it('renders a project', () => {
+    const props: IContentItem = {
+      tagName: 'projects',
+      content: [
+        {
+          description: 'Test description',
+          releaseDate: '2020-04-05',
+          slug: 'test-project',
+          title: 'Test Project',
+          topics: [
+            'test topic one',
+            'test topic two'
+          ]
+        }
+      ] as any
+    };
+    const { container } = render(
+      <ContentItem {...props} />
+    );
+
+    expect(container.querySelector('section')).toBeTruthy();
+    expect(container.querySelectorAll('div')).toHaveLength(1);
+    expect(screen.getByText('Test Project')).toBeTruthy();
+    expect(screen.getByText('Test description')).toBeTruthy();
+  });
+
+  it('renders a warning if the element is unknown', () => {
+    const props: IContentItem = {} as any;
+    const { container } = render(
+      <ContentItem {...props} />
+    );
+
+    expect(container.querySelector('span')).toBeTruthy();
+    expect(screen.getByText('Unknown element')).toBeTruthy();
+  })
+});

--- a/src/app/components/contentItem/ContentItem.tsx
+++ b/src/app/components/contentItem/ContentItem.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { ContentTypes, IContentItem, ITopic, IPosition, IProject } from 'common/interfaces';
+import {
+  isContentItem,
+  isTopic,
+  isPosition,
+  isProject,
+} from 'common/utils';
+import {
+  HeadingSt,
+  ParagraphSt,
+  SectionSt,
+  ListSt,
+  ListItemSt,
+  PositionSt,
+  ProjectSt,
+  SubHeadingSt,
+  TopicSt,
+} from './ContentItem.css';
+
+export interface IProps extends IContentItem {
+  className?: string,
+  key?: string,
+}
+
+export const renderTag = (tagName: string, content: any, key?: string): JSX.Element => {
+  switch(tagName) {
+    case 'section': {
+      return <SectionSt key={key}>{content}</SectionSt>;
+    }
+    case 'p': {
+      return <ParagraphSt key={key}>{content}</ParagraphSt>;
+    }
+    case 'h1': {
+      return <HeadingSt key={key}>{content}</HeadingSt>;
+    }
+    case 'h2': {
+      return <SubHeadingSt key={key}>{content}</SubHeadingSt>;
+    }
+    case 'ul': {
+      return <ListSt key={key}>{content}</ListSt>;
+    }
+    case 'li': {
+      return <ListItemSt key={key}>{content}</ListItemSt>;
+    }
+    case 'topics': {
+      return <ListSt key={key}>{content}</ListSt>;
+    }
+    case 'jobs':
+    case 'projects': {
+      return <SectionSt key={key}>{content}</SectionSt>
+    }
+  }
+
+  return <span>{content}</span>;
+}
+
+export const renderTopic = (topic: ITopic): JSX.Element => {
+  return <TopicSt {...topic} key={topic.title} />;
+};
+
+export const renderPosition = (position: IPosition): JSX.Element => (
+  <PositionSt
+    {...position}
+    key={`${position.company}-${position.location}`}
+  />
+);
+
+export const renderProject = (project: IProject): JSX.Element => (
+  <ProjectSt
+    {...project}
+    key={project.title}
+  />
+);
+
+export const renderContent = (item: ContentTypes, key?: string): JSX.Element => {
+  if (isContentItem(item)) {
+    const { content, tagName } = item;
+
+    if (Array.isArray(content)) {
+      return renderTag(
+        tagName,
+        content.map((contentItem: ContentTypes, idx: number) => renderContent(contentItem, `${tagName}-${idx}`)),
+        key
+      );
+    }
+
+    return renderTag(tagName, content, key);
+  } else if (isTopic(item)) {
+    return renderTopic(item);
+  } else if (isPosition(item)) {
+    return renderPosition(item);
+  } else if (isProject(item)) {
+    return renderProject(item);
+  }
+
+  return <span>Unknown element</span>;
+};
+
+export const ContentItem = (contentItem: IProps): JSX.Element => renderContent(contentItem);

--- a/src/app/components/position/Position.css.tsx
+++ b/src/app/components/position/Position.css.tsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import {
+  colours,
+  fontSizes,
+  fontWeights,
+  letterSpacing,
+  lineHeight,
+} from 'app/styles';
+import { Topic } from 'app/components/topic/Topic';
+
+export const PositionSt = styled.div`
+  display: block;
+`;
+
+export const CompanyNameSt = styled.h3`
+  font-weight: ${fontWeights.bold};
+`;
+
+export const LocationAndRoleSt = styled.h4`
+  font-weight: ${fontWeights.bold};
+`;
+
+export const DateSt = styled.time`
+  font-weight: bold;
+`;
+
+export const TaskListSt = styled.ul`
+  display: block;
+`;
+
+export const TopicsListSt = styled.ul`
+  display: block;
+`;
+
+export const TaskItemSt = styled.li`
+  border: 1px solid ${colours.tertiary};
+`;
+
+export const TopicSt = styled(Topic)`
+  background-color: pink;
+`;

--- a/src/app/components/position/Position.spec.tsx
+++ b/src/app/components/position/Position.spec.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Position, IProps } from './Position';
+
+const defaultProps: IProps = {
+  company: 'Test company',
+  location: 'Test location',
+  role: 'Test role',
+  startDate: '2020-01-01',
+  tasks: ['Task one', 'Task two'],
+  topics: [
+    {
+      "category": "languages",
+      "description": "Test description",
+      "slug": "test-language",
+      "title": "TestLanguage"
+    },
+    {
+      "category": "tools",
+      "description": "Test description",
+      "slug": "test-tool",
+      "title": "TestTool"
+    },
+  ]
+};
+
+describe('Position tests', () => {
+  it('renders the component with the correct content', () => {
+    const { container } = render(
+      <Position {...defaultProps} />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('2020-01-01')).toBeTruthy();
+    expect(screen.getByText('to present')).toBeTruthy();
+    expect(screen.getByText('Test company')).toBeTruthy();
+    expect(screen.getByText('Test role / Test location')).toBeTruthy();
+    expect(screen.getByText('Task one')).toBeTruthy();
+    expect(screen.getByText('Task two')).toBeTruthy();
+    expect(screen.getByText('TestLanguage')).toBeTruthy();
+    expect(screen.getByText('TestTool')).toBeTruthy();
+  });
+
+  it('renders the end date', () => {
+    const { container } = render(
+      <Position {...defaultProps} endDate="2020-04-26" />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.queryByText('to present')).toBeFalsy();
+    expect(screen.getByText('2020-04-26')).toBeTruthy();
+  });
+});
+

--- a/src/app/components/position/Position.tsx
+++ b/src/app/components/position/Position.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { IPosition, ITopic } from 'common/interfaces';
+import {
+  CompanyNameSt,
+  DateSt,
+  LocationAndRoleSt,
+  PositionSt,
+  TaskListSt,
+  TopicsListSt,
+  TopicSt,
+  TaskItemSt,
+} from './Position.css';
+
+export interface IProps extends IPosition {
+  className?: string,
+}
+
+export const Position = ({
+  className,
+  company,
+  endDate,
+  location,
+  role,
+  startDate,
+  tasks,
+  topics,
+}: IProps): JSX.Element => (
+  <PositionSt className={className}>
+    <DateSt datetime={new Date(startDate)}>{startDate}</DateSt>
+    {endDate ? (
+      <DateSt datetime={new Date(endDate)}>
+        {endDate}
+      </DateSt>
+    ) : ' to present'}
+    <CompanyNameSt>
+      {company}
+    </CompanyNameSt>
+    <LocationAndRoleSt>
+      {role} / {location}
+    </LocationAndRoleSt>
+    <TaskListSt>
+      {tasks.map((task: string, idx: number) => <TaskItemSt key={idx}>{task}</TaskItemSt>)}
+    </TaskListSt>
+    <TopicsListSt>
+      {topics.map((topic: ITopic, idx: number) => <TopicSt {...topic} key={idx} />)}
+    </TopicsListSt>
+  </PositionSt>
+);

--- a/src/app/components/project/Project.css.tsx
+++ b/src/app/components/project/Project.css.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import {
+  colours,
+  fontSizes,
+  fontWeights,
+  letterSpacing,
+  lineHeight,
+} from 'app/styles';
+
+export const ProjectSt = styled.div`
+  display: block;
+`;
+
+export const TitleSt = styled.h3`
+  font-weight: ${fontWeights.bold};
+`;
+
+export const DescriptionSt = styled.p`
+  font-weight: ${fontWeights.normal};
+`;
+
+export const UrlSt = styled.a`
+  font-weight: normal;
+`;
+
+

--- a/src/app/components/project/Project.spec.tsx
+++ b/src/app/components/project/Project.spec.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Project, IProps } from './Project';
+
+const defaultProps: IProps = {
+  description: 'Test project description',
+  releaseDate: '2020-05-04',
+  slug: 'test-slug',
+  title: 'Test project title',
+  topics: [
+    'test-topic-1',
+    'test-topic-2',
+  ],
+};
+
+describe('Project tests', () => {
+  it('renders the component with the correct content', () => {
+    const { container } = render(
+      <Project {...defaultProps} />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Test project title')).toBeTruthy();
+    expect(screen.getByText('Test project description')).toBeTruthy();
+  });
+
+  it('renders the url', () => {
+    const { container } = render(
+      <Project {...defaultProps} url="https://test.dev" />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('https://test.dev')).toBeTruthy();
+  })
+});

--- a/src/app/components/project/Project.tsx
+++ b/src/app/components/project/Project.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { IProject } from 'common/interfaces';
+import {
+  ProjectSt,
+  TitleSt,
+  DescriptionSt,
+  UrlSt,
+} from './Project.css';
+
+export interface IProps extends IProject {
+  className?: string
+};
+
+export const Project = ({
+  className,
+  description,
+  title,
+  url,
+}: IProps): JSX.Element => (
+  <ProjectSt className={className}>
+    <TitleSt>
+      {title}
+    </TitleSt>
+    <DescriptionSt>
+      {description}
+    </DescriptionSt>
+    {url && (
+      <UrlSt href={url}>
+        {url}
+      </UrlSt>
+    )}
+  </ProjectSt>
+);

--- a/src/app/components/topic/Topic.css.tsx
+++ b/src/app/components/topic/Topic.css.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+import { colours } from 'app/styles';
+
+export const TopicSt = styled.span`
+  border: 1px solid ${colours.primary};
+`;

--- a/src/app/components/topic/Topic.spec.tsx
+++ b/src/app/components/topic/Topic.spec.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Topic, IProps } from './Topic';
+
+const defaultProps: IProps = {
+  title: 'Test title'
+};
+
+describe('Topic tests', () => {
+  it('renders the component', () => {
+    const { container } = render(
+      <Topic {...defaultProps} />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Test title')).toBeTruthy();
+  });
+});

--- a/src/app/components/topic/Topic.tsx
+++ b/src/app/components/topic/Topic.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { ITopic } from 'common/interfaces';
+import { TopicSt } from './Topic.css';
+
+export interface IProps extends ITopic {
+  className?: string,
+}
+
+export const Topic = ({ className, title }: IProps): JSX.Element => (
+  <TopicSt className={className}>{title}</TopicSt>
+);

--- a/src/app/styles/vars.ts
+++ b/src/app/styles/vars.ts
@@ -1,4 +1,4 @@
-import { Breakpoints, Colours, Fonts } from 'common/interfaces';
+import { Breakpoints, Colours, Fonts, FontWeights } from 'common/interfaces';
 
 export const sizes: Breakpoints = {
   sm: 320,
@@ -9,27 +9,35 @@ export const sizes: Breakpoints = {
 };
 
 export const fontSizes: Fonts = {
-  jumbo: '100px',
-  heading: '48px',
-  subheading: '32px',
-  text: '24px',
-  small: '12px',
+  jumbo: 100,
+  heading: 48,
+  subheading: 32,
+  text: 24,
+  small: 12,
+};
+
+
+export const fontWeights: FontWeights = {
+  bold: 500,
+  light: 200,
+  normal: 400,
+  superLight: 100,
 };
 
 export const letterSpacing: Fonts = {
-  jumbo: '20px',
-  heading: '12px',
-  subheading: '8px',
-  text: '2px',
-  small: '1px',
+  jumbo: 20,
+  heading: 12,
+  subheading: 8,
+  text: 2,
+  small: 1,
 }
 
 export const lineHeight: Fonts = {
-  jumbo: '120px',
-  heading: '64px',
-  subheading: '40px',
-  text: '32px',
-  small: '16px',
+  jumbo: 120,
+  heading: 64,
+  subheading: 40,
+  text: 32,
+  small: 16,
 }
 
 export const colours: Colours = {

--- a/src/app/views/page/ConnectedPage.tsx
+++ b/src/app/views/page/ConnectedPage.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
+import { useParams } from 'react-router-dom';
 import { fetchPage, PageActionTypes, resetPage } from './actions';
-import Page from './Page';
+import Page, { IProps } from './Page';
 
 const mapStateToProps = (state: any) => ({
   error: state.pageState.error,
@@ -18,4 +20,10 @@ export const mapDispatchToProps = (dispatch: Dispatch<PageActionTypes>) => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(Page);
+const Component = (props: IProps): JSX.Element => {
+  const { slug } = useParams();
+
+  return <Page {...props} slug={slug || 'home'} />;
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Component);

--- a/src/app/views/page/Page.spec.tsx
+++ b/src/app/views/page/Page.spec.tsx
@@ -1,8 +1,81 @@
-import { render } from '@testing-library/react';
-import Page from './Page';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page, { IProps } from './Page';
+
+const noop = (): void => {};
+const defaultProps = {
+  error: null,
+  pending: false,
+  page: {
+    contents: [],
+    description: 'Test page',
+    slug: 'test-page',
+    title: 'Test page'
+  },
+  slug: 'test-page',
+  fetchPage: noop,
+  resetPage: noop,
+};
 
 describe('Page tests', () => {
-  it('should render the component', () => {
-    expect(true).toBe(true);
+  it('renders the component', () => {
+    const { container } = render(
+      <Page {...defaultProps} />
+    );
+
+    expect(container).toBeTruthy();
+  });
+
+  it('fetches the page given a change in the slug', () => {
+    const spyFetchPage = jest.fn();
+
+    render(
+      <Page
+        {...defaultProps}
+        fetchPage={spyFetchPage}
+        slug="new-test-slug"
+      />
+    );
+
+    expect(spyFetchPage).toHaveBeenCalled();
+    expect(spyFetchPage).toHaveBeenCalledWith('new-test-slug');
+  });
+
+  it('renders the loading indicator', () => {
+    const { container } = render(
+      <Page {...defaultProps} pending />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Loading!')).toBeTruthy();
+  });
+
+  it('renders page content', () => {
+    const { container } = render(
+      <Page
+        {...defaultProps}
+        page={{
+          ...defaultProps.page,
+          contents: [
+            {
+              tagName: 'h1',
+              content: 'Test heading'
+            }
+          ]
+        }}
+      />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Test heading')).toBeTruthy();
+  });
+
+  it('renders an error message', () => {
+    const { container } = render(
+      <Page {...defaultProps} error="Test error" />
+    );
+
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Test error')).toBeTruthy();
   });
 });

--- a/src/app/views/page/Page.tsx
+++ b/src/app/views/page/Page.tsx
@@ -1,33 +1,47 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { IPage } from 'common/interfaces';
+import { IContentItem, IPage } from 'common/interfaces';
+import { ContentItem } from 'app/components/contentItem/ContentItem';
 import PageSt from './Page.css';
 
 export interface IProps {
   error: any,
   pending: boolean,
   page: IPage,
+  slug: string,
   fetchPage(slug: string): void,
   resetPage(): void,
 };
+
+const pageContents = ({ contents }: IPage): JSX.Element[] =>
+  contents.map((item: IContentItem, key: number): JSX.Element => (
+    <ContentItem {...item} key={`${key}`} />
+  )
+);
+
+const loadingSpinner = (): JSX.Element => <div>Loading!</div>;
+const errorMessage = (error: any): JSX.Element => <div>{error.toString()}</div>;
 
 const Page = ({
   error,
   pending,
   page,
+  slug,
   fetchPage,
   resetPage,
 }: IProps): JSX.Element => {
-  const { slug } = useParams();
 
   useEffect((): any => {
-    fetchPage(slug || 'home');
+    fetchPage(slug);
 
     return resetPage;
   }, [slug]);
 
   return (
-    <PageSt>{page?.title}</PageSt>
+    <PageSt>
+      {pending && loadingSpinner()}
+      {error && errorMessage(error)}
+      {!pending && page && pageContents(page)}
+    </PageSt>
   );
 };
 

--- a/src/common/interfaces/models.ts
+++ b/src/common/interfaces/models.ts
@@ -5,14 +5,26 @@ export interface IAppConfig {
   enableCache: boolean,
 }
 
-export interface IContentItem {
-  tagName: string,
-  content: string | IContentItem,
+export type ContentTypes = IContentItem | ITopic | IPosition | IProject | string;
+
+export interface ICategory {
+  title: string,
+  description?: string,
 }
 
 export interface ITopic {
-  title: string,
+  logoPath?: string,
+  category: string,
+  deprecated?: boolean,
   description: string,
+  slug: string,
+  title: string,
+}
+
+export interface IContentItem {
+  content: ContentTypes,
+  id?: string,
+  tagName: string,
 }
 
 export interface IPage {
@@ -22,12 +34,22 @@ export interface IPage {
   title: string,
 }
 
-export interface IJob {
-  contents: IContentItem[],
-  endDate?: Date,
+export interface IPosition {
+  company: string,
+  endDate?: string, // TODO better type safety
+  location: string,
   role: string,
-  startDate: Date,
+  startDate: string, // TODO better type safety
+  tasks: string[],
   topics: ITopic[],
 }
 
+export interface IProject {
+  description: string,
+  releaseDate: string, // TODO better type safety
+  slug: string,
+  title: string,
+  topics: string[],
+  url?: string,
+}
 

--- a/src/common/interfaces/types.ts
+++ b/src/common/interfaces/types.ts
@@ -11,11 +11,18 @@ export type Breakpoints = {
 }
 
 export type Fonts = {
-  jumbo: string,
-  heading: string,
-  subheading: string,
-  text: string,
-  small: string
+  jumbo: number,
+  heading: number,
+  subheading: number,
+  text: number,
+  small: number
+}
+
+export type FontWeights = {
+  bold: number,
+  light: number,
+  normal: number,
+  superLight: number,
 }
 
 export type Colours = {

--- a/src/common/utils/checkers.ts
+++ b/src/common/utils/checkers.ts
@@ -1,0 +1,14 @@
+import { IContentItem, IPosition, IProject, ITopic } from 'common/interfaces';
+
+export const isContentItem = (contentItem: any): contentItem is IContentItem => {
+  return (contentItem as IContentItem).tagName !== undefined;
+};
+
+export const isTopic = (topic: any): topic is ITopic =>
+  (topic as ITopic).category !== undefined;
+
+export const isPosition = (position: any): position is IPosition =>
+  (position as IPosition).role !== undefined;
+
+export const isProject = (project: any): project is IProject =>
+  (project as IProject).releaseDate !== undefined;

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,2 +1,3 @@
 /* istanbul ignore file */
 export * from './api';
+export * from './checkers';


### PR DESCRIPTION
#### What is this?
This PR adds basic content for all three pages of the site, and includes a content renderer that determines the content type, then selects the appropriate component to render. Items are also rendered recursively if needed.

Content for the landing page (home), CV and projects has been created.