### PR TITLE
fix: ensure environment variables working client and server side

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,10 @@
 export {};
+declare namespace NodeJS {
+  export interface Process {
+    browser: boolean
+  }
+}
+
 declare global {
   interface caches {
     open(string): Promise<any>,
@@ -7,6 +13,6 @@ declare global {
   }
 
   interface Window {
-    _PRELOADED_STATE_: any
+    [index: string]: any,
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "@testing-library/react": "^10.0.3",
+    "@types/node": "^14.0.1",
     "@types/node-fetch": "^2.5.5",
     "@types/react-redux": "^7.1.7",
     "@types/styled-components": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,8 @@
     <link rel="shortcut icon" href="/images/icons/logo-48.png">
     <link rel="apple-touch-icon" href="/images/icons/logo-192.png">
     <style type="text/css"></style>
+    <script type="text/javascript">const CLIENT=true;</script>
+    <script>BASE_URL</script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -1,9 +1,9 @@
 import { apiCall } from 'common/utils';
-import Config from 'common/config';
+import config from 'common/config';
 
 declare const self: ServiceWorkerGlobalScope;
 
-const { appIconSizes, cacheName } = Config;
+const { appIconSizes, cacheName } = config;
 const appIconPaths: string[] = appIconSizes.map((size: number) => `images/icons/logo-${size}.png`);
 const urlsToCache = [
   '/',

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,9 +1,20 @@
 /* istanbul ignore file */
 import { IAppConfig } from 'common/interfaces';
 
-export default {
-  baseUrl: process?.env?.BASE_URL || 'http://localhost:3000',
-  cacheName: process?.env?.CACHE_NAME || 'mattfinucane.com',
+const getConfig = (key: string): string | undefined => {
+  if (process?.browser) {
+    return window[key];
+  }
+
+  return process.env[key];
+};
+
+export const config = {
+  baseUrl: getConfig('BASE_URL') || 'http://localhost',
+  port: getConfig('PORT') || '3000',
+  cacheName: getConfig('CACHE_NAME') || 'mattfinucane.com',
   enableCache: Boolean(process?.env?.enableCache),
   appIconSizes: [48, 72, 96, 144, 168, 192],
 } as IAppConfig;
+
+export default config;

--- a/src/common/interfaces/models.ts
+++ b/src/common/interfaces/models.ts
@@ -1,55 +1,56 @@
 export interface IAppConfig {
-  readonly appIconSizes: number[],
+  readonly appIconSizes: number[];
   readonly baseUrl: string;
   readonly cacheName: string;
-  enableCache: boolean,
+  readonly port: string;
+  enableCache: boolean;
 }
 
 export type ContentTypes = IContentItem | ITopic | IPosition | IProject | string;
 
 export interface ICategory {
-  title: string,
-  description?: string,
+  title: string;
+  description?: string;
 }
 
 export interface ITopic {
-  logoPath?: string,
-  category: string,
-  deprecated?: boolean,
-  description: string,
-  slug: string,
-  title: string,
+  logoPath?: string;
+  category: string;
+  deprecated?: boolean;
+  description: string;
+  slug: string;
+  title: string;
 }
 
 export interface IContentItem {
-  content: ContentTypes,
-  id?: string,
-  tagName: string,
+  content: ContentTypes;
+  id?: string;
+  tagName: string;
 }
 
 export interface IPage {
-  contents: IContentItem[],
-  description: string,
-  slug: string,
-  title: string,
+  contents: IContentItem[];
+  description: string;
+  slug: string;
+  title: string;
 }
 
 export interface IPosition {
-  company: string,
-  endDate?: string, // TODO better type safety
-  location: string,
-  role: string,
-  startDate: string, // TODO better type safety
-  tasks: string[],
-  topics: ITopic[],
+  company: string;
+  endDate?: string; // TODO better type safety
+  location: string;
+  role: string;
+  startDate: string; // TODO better type safety
+  tasks: string[];
+  topics: ITopic[];
 }
 
 export interface IProject {
-  description: string,
-  releaseDate: string, // TODO better type safety
-  slug: string,
-  title: string,
-  topics: string[],
-  url?: string,
+  description: string;
+  releaseDate: string; // TODO better type safety
+  slug: string;
+  title: string;
+  topics: string[];
+  url?: string;
 }
 

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -2,9 +2,9 @@ import fetch, { RequestInit, Response } from 'node-fetch';
 import config from 'common/config';
 
 export const apiCall = async (url: string, options: RequestInit = { method: 'GET' }): Promise<any> => {
-  const { baseUrl } = config;
+  const { baseUrl, port } = config;
 
-  return await fetch(`${baseUrl}${url}`, options) as Response;
+  return await fetch(`${baseUrl}:${port}${url}`, options) as Response;
 };
 
 export default apiCall;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3,17 +3,21 @@ import config from 'common/config';
 import { IBaseController } from 'server/interfaces';
 
 interface IApp {
-  port: number;
+  baseUrl: string;
+  port: string;
   controllers: IBaseController[];
 }
 
 class App {
   public app: Application;
 
-  public port: number;
+  public port: string;
 
-  constructor({ controllers, port }: IApp) {
+  public baseUrl: string;
+
+  constructor({ controllers, baseUrl, port }: IApp) {
     this.app = express();
+    this.baseUrl = baseUrl;
     this.port = port;
     this.setupRoutes(controllers);
   }
@@ -27,7 +31,7 @@ class App {
   public listen() {
     this.app.listen(this.port, () => {
       // eslint-disable-next-line no-console
-      console.log(`App listening on http://localhost:${this.port} with service worker caching ${config.enableCache ? 'enabled' : 'disabled'}`);
+      console.log(`App listening on ${this.baseUrl}:${this.port} with service worker caching ${config.enableCache ? 'enabled' : 'disabled'}`);
     });
   }
 }

--- a/src/server/controllers/SSRController.tsx
+++ b/src/server/controllers/SSRController.tsx
@@ -41,7 +41,7 @@ class SSRController implements IBaseController {
     const preloadedState: any = this.store.getState();
     const indexPath: string = `${this.baseFilePath}/index.html`;
     const preloadedStateJson: string = JSON.stringify(preloadedState).replace(/</g, '\\u003c');
-    const { enableCache } = config;
+    const { enableCache, baseUrl } = config;
     let reactAppHtml: string;
     let styleTags: string;
 
@@ -74,7 +74,8 @@ class SSRController implements IBaseController {
         )
         .replace(
           // eslint-disable-next-line quotes
-          `<div id="root"></div>`, `<div id="root">${reactAppHtml}</div>`,
+          `<div id="root"></div>`,
+          `<div id="root">${reactAppHtml}</div>`,
         )
         .replace(
           '<script>PRELOADED_STATE</script>',
@@ -83,6 +84,9 @@ class SSRController implements IBaseController {
         .replace(
           'ENABLE_CACHE',
           enableCache ? 'true' : 'false'
+        ).replace(
+          '<script>BASE_URL</script>',
+          `<script type="text/javascript">window.BASE_URL = '${baseUrl}';</script>`,
         );
 
       return res

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,10 +1,14 @@
 import AssetsController from 'server/controllers/AssetsController';
 import SSRController from 'server/controllers/SSRController';
 import ContentController from 'server/controllers/ContentController';
+import config from 'common/config';
 import App from './app';
 
+const { baseUrl, port } = config;
+
 const app = new App({
-  port: 3000,
+  baseUrl,
+  port,
   controllers: [
     new ContentController(),
     new AssetsController(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,6 +1351,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.2.tgz#160d82623610db590a64e8ca81784e11117e5a54"
   integrity sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==
 
+"@types/node@^14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.1.tgz#5d93e0a099cd0acd5ef3d5bde3c086e1f49ff68c"
+  integrity sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
#### What is this?
This is a small fix to ensure that environment variables work client and server side. They can be set via the command line before running `yarn server`.

To override the default `baseUrl` of `http://localhost`, do the following:
- `BASE_URL=http://12.34.56.78 yarn server`

This will set the BASE_URL to the above value both client and server side.