### PR TITLE
feat: create regex to extract links from markdown flavoured content

### DIFF
--- a/assets/pages/home.json
+++ b/assets/pages/home.json
@@ -356,7 +356,7 @@
         },
         {
           "tagName": "p",
-          "content": "Please feel free to checkout my [CV](/cv), which details my qualifications, skillsets and work experience. Here are some of the [projects](/projects) I have worked on."
+          "content": "Please feel free to checkout my [cv](cv \"My CV/Resumé\"), which details my qualifications, skillsets and work experience. Here are some of the [projects](/projects \"My projects\") I have worked on."
         }
       ]
     }

--- a/src/app/components/contentItem/ContentItem.css.tsx
+++ b/src/app/components/contentItem/ContentItem.css.tsx
@@ -1,11 +1,15 @@
 import styled, { css } from 'styled-components';
 import {
+  animationCurve,
+  colours,
   headingTypography,
+  layers,
   listItemStyle,
   media,
   subHeadingTypography,
   textTypography,
 } from 'app/styles';
+import { InlineLink } from 'app/components/inlinelink/InlineLink';
 import { Topic } from 'app/components/topic/Topic';
 
 export const SectionSt = styled.section`
@@ -43,4 +47,29 @@ export const TopicSt = styled(Topic)`
   ${media.md(css`
     margin: 0.25rem;
   `)}
+`;
+
+export const LinkSt = styled(InlineLink)`
+  position: relative;
+  transition: color 200ms ${animationCurve};
+
+  &::after {
+    z-index: ${layers.lower};
+    position: absolute;
+    bottom: -0.125rem;
+    left: 0;
+    width: 100%;
+    height: 0.125rem;
+    background-color: ${colours.primary};
+    content: "";
+    transition: height 200ms ${animationCurve};
+  }
+
+  &:hover {
+    color: ${colours.secondary};
+
+    &::after {
+      height: 100%;
+    }
+  }
 `;

--- a/src/app/components/contentItem/ContentItem.spec.tsx
+++ b/src/app/components/contentItem/ContentItem.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IContentItem } from 'common/interfaces';
-import { ContentItem, IProps } from './ContentItem';
-import { ProjectSt } from '../project/Project.css';
+import { ContentItem, processContent } from './ContentItem';
+import { LinkSt } from './ContentItem.css';
 
 describe('ContentItem tests', () => {
   it('renders the component', () => {
@@ -15,6 +15,31 @@ describe('ContentItem tests', () => {
 
     expect(container).toBeTruthy();
     expect(screen.getByText('This is a test')).toBeTruthy();
+  });
+
+  it('processes content that contains links and renders them', () => {
+    const { container } = render(
+      <ContentItem
+        tagName="p"
+        content="This contains [a link](/test-link) to render"
+      />
+    );
+    const link = container.getElementsByTagName('a')[0];
+
+    expect(link).toBeTruthy();
+    expect(link.href).toContain('/test-link');
+  });
+
+  it('processes content that contains no links', () => {
+    const { container } = render(
+      <ContentItem
+        tagName="p"
+        content="This contains no links to render"
+      />
+    );
+    const link = container.getElementsByTagName('a')[0];
+
+    expect(link).toBeFalsy();
   });
 
   describe('rendering standard html tags', () => {

--- a/src/app/components/contentItem/ContentItem.tsx
+++ b/src/app/components/contentItem/ContentItem.tsx
@@ -2,14 +2,18 @@ import * as React from 'react';
 import { ContentTypes, IContentItem, ITopic, IPosition, IProject } from 'common/interfaces';
 import {
   isContentItem,
+  isLink,
   isTopic,
   isPosition,
   isProject,
+  splitContent,
+  toLinkObject,
 } from 'common/utils';
 import { Position } from 'app/components/position/Position';
 import { Project } from 'app/components/project/Project';
 import {
   HeadingSt,
+  LinkSt,
   ParagraphSt,
   SectionSt,
   ListSt,
@@ -23,13 +27,30 @@ export interface IProps extends IContentItem {
   key?: string,
 }
 
+export const processContent = (content: string): any => {
+  const split: string[] = splitContent(content);
+  const processed = split.map((item: string, idx: number) => {
+    if (isLink(item)) {
+      return <LinkSt {...toLinkObject(item)} key={idx} />
+    }
+
+    return item;
+  });
+
+  return processed;
+};
+
 export const renderTag = (tagName: string, content: any, key?: string): JSX.Element => {
   switch(tagName) {
     case 'section': {
       return <SectionSt key={key}>{content}</SectionSt>;
     }
     case 'p': {
-      return <ParagraphSt key={key}>{content}</ParagraphSt>;
+      return (
+        <ParagraphSt key={key}>
+          {processContent(content)}
+        </ParagraphSt>
+      );
     }
     case 'h1': {
       return <HeadingSt key={key}>{content}</HeadingSt>;
@@ -42,7 +63,11 @@ export const renderTag = (tagName: string, content: any, key?: string): JSX.Elem
       return <ListSt key={key}>{content}</ListSt>;
     }
     case 'li': {
-      return <ListItemSt key={key}>{content}</ListItemSt>;
+      return (
+        <ListItemSt key={key}>
+          {processContent(content)}
+        </ListItemSt>
+      );
     }
     case 'topics': {
       return <ListSt key={key}>{content}</ListSt>;

--- a/src/app/components/inlinelink/InlineLink.spec.tsx
+++ b/src/app/components/inlinelink/InlineLink.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { InlineLink, IProps } from './InlineLink';
+
+const defaultProps: IProps = {
+  text: 'Test Link',
+  url: '/test/link',
+};
+
+describe('InlineLink tests', () => {
+  it('renders the component', () => {
+    const wrapper = render(<InlineLink {...defaultProps} />);
+    const link = wrapper.getByText('Test Link') as HTMLLinkElement;
+
+    expect(wrapper).toBeTruthy();
+    expect(link).toBeTruthy();
+    expect(link.href).toContain('/test/link');
+    expect(link.title).toEqual('');
+  });
+
+  it('renders with a title', () => {
+    const wrapper = render(<InlineLink {...defaultProps} title="Test title" />);
+    const link = wrapper.getByText('Test Link') as HTMLLinkElement;
+
+    expect(wrapper).toBeTruthy();
+    expect(link.title).toEqual('Test title');
+  });
+});

--- a/src/app/components/inlinelink/InlineLink.tsx
+++ b/src/app/components/inlinelink/InlineLink.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export interface IProps {
+  className?: string,
+  text: string,
+  title?: string,
+  url: string,
+};
+
+export const InlineLink = ({ className, text, title, url }: IProps): JSX.Element => (
+  <a className={className} href={url} title={title}>
+    {text}
+  </a>
+);

--- a/src/app/components/nav/Nav.css.tsx
+++ b/src/app/components/nav/Nav.css.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { animationCurve, colours } from 'app/styles';
 import { Link } from 'react-router-dom';
 
 interface ILinkStProps {
@@ -22,9 +23,8 @@ export const LinkSt = styled(Link)<ILinkStProps>`
     left: 0;
     width: 0;
     height: 0.125rem;
-    background-color: currentColor;
-    transition-property: width;
-    transition-duration: 300ms;
+    background-color: ${colours.primary};
+    transition: width 200ms ${animationCurve};
     content: "";
   }
 

--- a/src/app/components/project/Project.css.tsx
+++ b/src/app/components/project/Project.css.tsx
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import {
+  animationCurve,
   colours,
   media,
   subHeadingTypography,
@@ -10,18 +11,14 @@ export const ProjectSt = styled.a`
   position: relative;
   display: block;
   margin: 1rem 0;
-  transition-property: transform;
-  transition-duration: 100ms;
+  padding: 0 0.5rem;
+  transition: all 200ms ${animationCurve};
+  transition-property: background-color colour;
 
   &:hover {
-    transform: scale3d(1.03, 1.03, 1.0);
+    background-color: ${colours.primary};
+    color: ${colours.secondary};
   }
-
-  ${media.md(css`
-    &:hover {
-      transform: scale3d(1.01, 1.01, 1.0);
-    }
-  `)};
 
   &::after {
     display: flex;

--- a/src/common/interfaces/models.ts
+++ b/src/common/interfaces/models.ts
@@ -22,6 +22,12 @@ export interface ITopic {
   title: string;
 }
 
+export interface ILink {
+  text: string,
+  title?: string,
+  url: string,
+}
+
 export interface IContentItem {
   content: ContentTypes;
   id?: string;

--- a/src/common/utils/utils.spec.ts
+++ b/src/common/utils/utils.spec.ts
@@ -1,7 +1,65 @@
-import { formatDate } from './utils';
+import { formatDate, isLink, toLinkObject, splitContent } from './utils';
+import { utimes } from 'fs';
 
 describe('utils tests', () => {
   it('should format a date', () => {
     expect(formatDate(new Date('1982-04-26'))).toEqual('April 1982');
+  });
+
+  it('should check if a string is an MD formatted link', () => {
+    expect(isLink('Nothing in here!')).toBe(false);
+    expect(isLink()).toBe(false);
+    expect(isLink('I like to code in Javascript (ES)')).toBe(false);
+    expect(isLink('[page](https://www.test.dd)')).toBe(true);
+  });
+
+  it('checks to see if a string contains a markdown flavoured link', () => {
+    expect(isLink('I am not a link!')).toBe(false);
+    expect(isLink('I do indeed [have a link](/link "A link!") contained in me!')).toBe(true);
+    expect(isLink('I am [a link](/a-link) with no title!')).toBe(true);
+    expect(isLink('I am [a malformed] (/a-link) because of the space!')).toBe(false);
+  });
+
+  it('converts a markdown style link to a link object', () => {
+    expect(
+      toLinkObject('[test link with title](/test "Test")')
+    ).toEqual({
+      text: 'test link with title',
+      title: 'Test',
+      url: '/test'
+    });
+
+    expect(
+      toLinkObject('[test link without title](/test)')
+    ).toEqual({
+      text: 'test link without title',
+      url: '/test'
+    });
+
+    expect(
+      toLinkObject('A normal line of text with no links')
+    ).toEqual({
+      text: 'malformed link',
+      title: 'malformed link',
+      url: '/'
+    });
+  });
+
+  it('splits out content if a markdown flavoured link is found', () => {
+    expect(
+      splitContent('I am a normal parahraph with no links')
+    ).toEqual([
+      'I am a normal parahraph with no links'
+    ]);
+
+    expect(
+      splitContent('I have [a couple](/some-links "Links") of links and [another one](/another) right here!')
+    ).toEqual([
+      'I have ',
+      '[a couple](/some-links "Links")',
+      ' of links and ',
+      '[another one](/another)',
+      ' right here!'
+    ]);
   });
 });

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -1,3 +1,4 @@
+import { ILink } from 'common/interfaces';
 const months: string[] = [
   'January',
   'February',
@@ -22,4 +23,35 @@ export const formatDate = (date: Date): string => {
 
 export const setBodyOverflow = (overflow: boolean): void => {
   document.body.style.overflow = overflow ? 'auto' : 'hidden';
+};
+
+export const isLink = (text?: string): boolean => {
+  const regexp: RegExp = /(\[.*?\]\(.*?\))/;
+
+  return regexp.test(text || '');
+};
+
+export const toLinkObject = (linkText: string): ILink => {
+  const regexp: RegExp = /\[(?<text>.*?)\]\((?<url>.*?)("(?<title>.*?)")?\)/gm;
+  const result: any = regexp.exec(linkText);
+
+  if (!result) {
+    return {
+      text: 'malformed link',
+      title: 'malformed link',
+      url: '/',
+    };
+  }
+
+  return {
+    text: result?.groups?.text,
+    ...(result.groups.title && { title: result.groups.title }),
+    url: result?.groups?.url.trim(),
+  };
+}
+
+export const splitContent = (text: string): string[] => {
+  const regexp: RegExp = /(\[.*?\]\(.*?\))/gm;
+
+  return text.split(regexp);
 };

--- a/src/server/controllers/SSRController.spec.ts
+++ b/src/server/controllers/SSRController.spec.ts
@@ -171,7 +171,7 @@ describe('SSRController tests', () => {
     const res: Response = {
       status: spyStatus,
     } as any;
-    const expected = { error: new Error('cannot-render-to-string') };
+    const expected = { error: new Error('cannot-render-to-string').toString() };
 
     spyGetState.mockResolvedValue({ test: 'state' });
     renderToString.mockImplementation(() => {

--- a/src/server/controllers/SSRController.tsx
+++ b/src/server/controllers/SSRController.tsx
@@ -60,7 +60,7 @@ class SSRController implements IBaseController {
       styleTags = sheet.getStyleTags();
       helmet = Helmet.renderStatic();
     } catch (error) {
-      return res.status(500).json({ error });
+      return res.status(500).json({ error: error.toString() });
     } finally {
       sheet.seal();
     }


### PR DESCRIPTION
#### What is this
This PR adds the ability to extract links from markdown flavoured content, and render them in place (inside lists and paragraphs).

The appearance of links across has also been improved with some styling tweaks.

#### How does this work?
If there is a content string that contains a markdown flavoured link definition, such as follows:

```
'This is [an example](/example "Example") of a link'
```

Then I have created a regex parser to split the string apart, so that it changes to an array as follows:
```
[
  'This is ',
  '[an example](/example "Example")',
  ' of a link' 
]
```

If I can use the correct pattern matching, I can then isolate the second item and convert it to an object, which I then use as properties for a simple link component I have created in React.

The resulting payload as follows gets re-rendered into a parent paragraph styled component as a combination of text and <a> element DOM nodes.

```
[
  'This is ',
  <InlineLink {...linkProps} />,
  ' of a link' 
]
```
