### PR TITLE
feat: kick off work with a functioning set of themes

### DIFF
--- a/assets/images/svg/closingtag.svg
+++ b/assets/images/svg/closingtag.svg
@@ -3,7 +3,7 @@
 	 viewBox="0 0 53 37" style="enable-background:new 0 0 53 37;" xml:space="preserve">
 	<style type="text/css">
 		.st0{display:none;}
-		.st1{fill:#000;}
+		.st1{fill:#fff;}
 	</style>
 	<g>
 		<g>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,22 +1,38 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
+import { ThemeType } from 'common/interfaces';
 import ConnectedPage from 'app/views/page/ConnectedPage';
 import { Meta } from 'app/components/meta/Meta';
-import { GlobalStyle } from 'app/styles';
+import { day, GlobalStyle, night } from 'app/styles';
 
-const App = (): JSX.Element => (
-  <ThemeProvider theme={{}}>
-    <Meta
-      description="Matt Finucane is a Dublin based software engineer."
-      title="Matt Finucane - Software engineer"
-      slug="/"
-    />
-    <Switch>
-      <Route path="/:slug?" exact component={ConnectedPage} />
-    </Switch>
-    <GlobalStyle />
-  </ThemeProvider>
-);
+const mapStateToProps = (state: any) => ({
+  currentTheme: state.appState.currentTheme,
+});
 
-export default App;
+export interface IProps {
+  currentTheme: ThemeType,
+}
+
+const App = ({ currentTheme }: IProps): JSX.Element => {
+  const themes = {
+    day, night,
+  };
+
+  return (
+    <ThemeProvider theme={themes[currentTheme]}>
+      <Meta
+        description="Matt Finucane is a Dublin based software engineer."
+        title="Matt Finucane - Software engineer"
+        slug="/"
+      />
+      <Switch>
+        <Route path="/:slug?" exact component={ConnectedPage} />
+      </Switch>
+      <GlobalStyle />
+    </ThemeProvider>
+  );
+};
+
+export default connect(mapStateToProps)(App);

--- a/src/app/actions.spec.ts
+++ b/src/app/actions.spec.ts
@@ -1,0 +1,17 @@
+import { ThemeType } from 'common/interfaces';
+import { SWITCH_THEME } from './types';
+import { switchTheme } from './actions';
+
+describe('app actions tests', () => {
+  it('sets the current theme', () => {
+    expect(switchTheme(ThemeType.DAY)).toEqual({
+      type: SWITCH_THEME,
+      payload: ThemeType.DAY,
+    });
+
+    expect(switchTheme(ThemeType.NIGHT)).toEqual({
+      type: SWITCH_THEME,
+      payload: ThemeType.NIGHT,
+    });
+  });
+});

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,14 @@
+import { ThemeType } from 'common/interfaces';
+import { SWITCH_THEME } from './types';
+
+export interface ISwitchThemeType {
+  type: typeof SWITCH_THEME,
+  payload: ThemeType,
+}
+
+export type AppActionTypes = ISwitchThemeType;
+
+export const switchTheme = (theme: ThemeType): AppActionTypes => ({
+  type: SWITCH_THEME,
+  payload: theme,
+});

--- a/src/app/components/contentItem/ContentItem.css.tsx
+++ b/src/app/components/contentItem/ContentItem.css.tsx
@@ -60,13 +60,13 @@ export const LinkSt = styled(InlineLink)`
     left: 0;
     width: 100%;
     height: 0.125rem;
-    background-color: ${colours.primary};
+    background-color: ${props => props?.theme?.colours?.primary};
     content: "";
     transition: height 200ms ${animationCurve};
   }
 
   &:hover {
-    color: ${colours.secondary};
+    color: ${props => props?.theme?.colours?.secondary};
 
     &::after {
       height: 100%;

--- a/src/app/components/footer/Footer.css.tsx
+++ b/src/app/components/footer/Footer.css.tsx
@@ -1,9 +1,16 @@
 import styled from 'styled-components';
+import { ClosingTag } from 'app/components/svgicons';
 
 export const FooterSt = styled.footer`
   display: flex;
   justify-content: center;
   align-items: center;
+`;
+
+export const ClosingTagSt = styled(ClosingTag)`
+  width: 48px;
+  height: 48px;
+  fill: ${props => props?.theme?.colours?.primary};
 `;
 
 export default FooterSt;

--- a/src/app/components/footer/Footer.tsx
+++ b/src/app/components/footer/Footer.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import FooterSt from './Footer.css';
-import closingtag from 'svg/closingtag.svg';
+import FooterSt, { ClosingTagSt } from './Footer.css';
 
 export interface IProps {
-  className?: string
+  className?: string,
 }
 
 export const Footer = ({ className }: IProps) => (
   <FooterSt className={className}>
-    <img src={closingtag} width="48" height="48" />
+    <ClosingTagSt />
   </FooterSt>
 );

--- a/src/app/components/loading/Loading.css.tsx
+++ b/src/app/components/loading/Loading.css.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes } from 'styled-components';
-import { animationCurve, layers } from 'app/styles';
+import { layers } from 'app/styles';
 
 const rotate = keyframes`
   from {

--- a/src/app/components/menubutton/MenuButton.css.tsx
+++ b/src/app/components/menubutton/MenuButton.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
-import { animationCurve, colours } from 'app/styles';
+import { animationCurve } from 'app/styles';
 
 export enum LinePlacement {
   TOP = 'top',
@@ -37,13 +37,13 @@ export const MenuButtonSt = styled.button`
   flex-direction: column;
   justify-content: space-around;
   padding: 0.5rem;
-  background-color: ${colours.secondary};
+  background-color: ${props => props?.theme?.colours?.secondary};
 `;
 
 export const LineSt = styled.span<ListStProps>`
   width: 2rem;
   height: 1px;
-  background: ${colours.primary};
+  background: ${props => props?.theme?.colours?.primary};
   transform-origin: center center;
   transition: transform 0.5s ${animationCurve}, rotate 0.5s ${animationCurve};
 

--- a/src/app/components/meta/Meta.tsx
+++ b/src/app/components/meta/Meta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { colours } from 'app/styles';
 import { Helmet } from 'react-helmet';
 import config from 'common/config';
+import { colours } from 'app/styles/vars';
 
 export interface IProps {
   description: string,

--- a/src/app/components/nav/Nav.css.tsx
+++ b/src/app/components/nav/Nav.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { animationCurve, colours, layers } from 'app/styles';
+import { animationCurve, layers } from 'app/styles';
 import { Link } from 'react-router-dom';
 
 interface ILinkStProps {
@@ -28,27 +28,27 @@ export const LinkSt = styled(Link)<ILinkStProps>`
     left: 0;
     width: 100%;
     height: 0;
-    background: ${colours.primary};
+    background: ${props => props?.theme?.colours?.primary};
     transition: all 200ms ${animationCurve};
     transition-property: background height;
     content: "";
   }
 
   &:hover {
-    color: ${colours.secondary};
+    color: ${props => props?.theme?.colours?.secondary};
 
     &::after {
       height: 100%;
-      background: ${colours.primary};
+      background: ${props => props?.theme?.colours?.primary};
     }
   }
 
   ${(props) => props.isactive === 'true' && css`
-    color: ${colours.secondary};
+    color: ${props => props?.theme?.colours?.secondary};
 
     &::after {
       height: 100%;
-      background: ${colours.primary};
+      background: ${props => props?.theme?.colours?.primary};
     }
   `};
 `;

--- a/src/app/components/svgicons.tsx
+++ b/src/app/components/svgicons.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface IProps {
+  className?: string,
+  primaryFill?: string,
+  secondaryFill?: string,
+}
+
+export const ClosingTag = ({ className }: IProps): JSX.Element => (
+  <svg
+    className={className}
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    viewBox="0 0 53 37"
+    xmlSpace="preserve">
+  >
+    <g>
+      <g>
+        <path d="M0.8,19.5v-2.4l13.8-7v2.5L3.7,18.3l10.9,5.7v2.5L0.8,19.5z"/>
+      </g>
+      <g>
+        <path d="M52.2,19.5l-13.8,7.1v-2.5l10.9-5.7l-10.9-5.7v-2.5l13.8,7V19.5z"/>
+      </g>
+      <g>
+        <path d="M32,0h2.4L22.9,36.9h-2.5L32,0z"/>
+      </g>
+    </g>
+  </svg>
+);

--- a/src/app/components/toggle/Toggle.css.tsx
+++ b/src/app/components/toggle/Toggle.css.tsx
@@ -1,0 +1,48 @@
+import styled, { css } from 'styled-components';
+import { animationCurve, layers } from 'app/styles';
+
+interface IToggleIndicatorStProps {
+  switchedOn?: boolean
+}
+
+const iconStyle = css`
+  position: absolute;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  color: transparent;
+  text-shadow: 0 0 0 ${props => props?.theme?.colours?.primary};
+  top: 0;
+`;
+
+export const ToggleTrackSt = styled.div`
+  position: relative;
+  border: 2px solid ${props => props?.theme?.colours?.primary};
+  width: 3rem;
+  height: 1.5rem;
+  border-radius: 2.75rem;
+
+  &::before {
+    ${iconStyle};
+    left: 0.125rem;
+    content: "☀️";
+  }
+
+  &::after {
+    ${iconStyle};
+    right: 0;
+    content: "🌙";
+  }
+`;
+
+export const ToggleIndicatorSt = styled.div<IToggleIndicatorStProps>`
+  z-index: ${layers.upper};
+  position: absolute;
+  top: 0;
+  left: ${props => props.switchedOn ? '1.5rem' : 0};
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: ${props => props?.theme?.colours?.primary};
+
+  transition: left 200ms ${animationCurve};
+`;

--- a/src/app/components/toggle/Toggle.spec.tsx
+++ b/src/app/components/toggle/Toggle.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import 'jest-styled-components';
+import { fireEvent, render } from '@testing-library/react';
+import { ToggleValue } from 'common/interfaces';
+import { Toggle, IProps } from './Toggle';
+
+const defaultProps: IProps = {
+  value: ToggleValue.OFF
+};
+
+describe('Toggle tests', () => {
+  it('renders the component', () => {
+    expect(
+      render(<Toggle {...defaultProps} />)
+    ).toBeTruthy();
+  });
+
+  it('toggles to the ON value', () => {
+    const spyOnToggle = jest.fn();
+    const wrapper = render(<Toggle {...defaultProps} onToggle={spyOnToggle} />);
+    const toggle = wrapper.getByTestId('toggle');
+
+    fireEvent.click(toggle);
+    expect(spyOnToggle).toHaveBeenCalledWith(ToggleValue.ON);
+  });
+
+  it('toggles to the OFF value', () => {
+    const spyOnToggle = jest.fn();
+    const wrapper = render(
+      <Toggle {...defaultProps} onToggle={spyOnToggle} value={ToggleValue.ON} />
+    );
+    const toggle = wrapper.getByTestId('toggle');
+
+    fireEvent.click(toggle);
+    expect(spyOnToggle).toHaveBeenCalledWith(ToggleValue.OFF);
+  });
+
+  it('shows the correct toggle position given OFF state', () => {
+    const wrapper = render(<Toggle {...defaultProps} />);
+    const indicator = wrapper.getByTestId('indicator');
+
+    expect(indicator).toHaveStyleRule('left', '0');
+  });
+
+  it('shows the correct toggle position given ON state', () => {
+    const wrapper = render(<Toggle {...defaultProps} value={ToggleValue.ON} />);
+    const indicator = wrapper.getByTestId('indicator');
+
+    expect(indicator).toHaveStyleRule('left', '1.5rem');
+  });
+});

--- a/src/app/components/toggle/Toggle.tsx
+++ b/src/app/components/toggle/Toggle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ToggleValue } from 'common/interfaces';
+import { ToggleIndicatorSt, ToggleTrackSt } from './Toggle.css';
+
+export interface IProps {
+  className?: string,
+  value: ToggleValue,
+  onToggle?(value: ToggleValue): void,
+};
+
+export const Toggle = ({ className, value, onToggle }: IProps): JSX.Element => {
+  const onToggleTrackClick = (): void => {
+    onToggle && onToggle(value === ToggleValue.ON ? ToggleValue.OFF : ToggleValue.ON);
+  }
+
+  return (
+    <ToggleTrackSt
+      className={className}
+      data-testid="toggle"
+      onClick={onToggleTrackClick}
+    >
+      <ToggleIndicatorSt data-testid="indicator" switchedOn={value === ToggleValue.ON} />
+    </ToggleTrackSt>
+  );
+};

--- a/src/app/components/topic/Topic.css.tsx
+++ b/src/app/components/topic/Topic.css.tsx
@@ -3,7 +3,8 @@ import { colours, textTypography } from 'app/styles';
 
 export const TopicSt = styled.li`
   ${textTypography};
+  color: ${colours.primary};
   border-radius: 0.25rem;
   padding: 0.5rem;
-  background: ${colours.tertiary};
+  background: ${props => props?.theme?.colours?.tertiary};
 `;

--- a/src/app/reducer.spec.ts
+++ b/src/app/reducer.spec.ts
@@ -1,0 +1,18 @@
+import { ThemeType } from 'common/interfaces';
+import { SWITCH_THEME } from './types';
+import { defaultState, appState } from './reducer';
+
+describe('app reducer tests', () => {
+  it('updates the state when the current theme is set', () => {
+    const state = appState(undefined, {
+      type: SWITCH_THEME,
+      payload: ThemeType.DAY,
+    });
+    const check = {
+      ...defaultState,
+      currentTheme: ThemeType.DAY,
+    };
+
+    expect(state).toEqual(check);
+  });
+});

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -1,0 +1,25 @@
+import { IAction, IAppState, ThemeType } from 'common/interfaces';
+import { SWITCH_THEME } from './types';
+
+export const defaultState: IAppState = {
+  currentTheme: ThemeType.DAY,
+};
+
+export const appState = (
+  state: IAppState = defaultState,
+  action: IAction,
+): IAppState => {
+  const { payload, type } = action;
+
+  switch (type) {
+    case SWITCH_THEME: {
+      return {
+        ...defaultState,
+        currentTheme: payload,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};

--- a/src/app/styles/global.ts
+++ b/src/app/styles/global.ts
@@ -1,5 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
-import { colours, defaultFont } from './vars';
+import { defaultFont } from './vars';
 
 export const GlobalStyle = createGlobalStyle`
   * {
@@ -9,8 +9,8 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   body {
-    color: ${colours.primary};
-    background: ${colours.secondary};
+    color: ${props => props.theme.colours.primary};
+    background: ${props => props.theme.colours.secondary};
     font-family: ${defaultFont};
   }
 

--- a/src/app/styles/index.ts
+++ b/src/app/styles/index.ts
@@ -3,3 +3,4 @@ export * from './mixins';
 export * from './vars';
 export * from './global';
 export * from './typography';
+export * from './themes';

--- a/src/app/styles/themes.ts
+++ b/src/app/styles/themes.ts
@@ -1,0 +1,18 @@
+import { colours } from './vars';
+
+export const day = {
+  colours: {
+    primary: colours.primary,
+    secondary: colours.secondary,
+    tertiary: colours.tertiary,
+  },
+};
+
+export const night = {
+  colours: {
+    primary: colours.secondary,
+    secondary: colours.primary,
+    tertiary: colours.tertiary,
+  },
+};
+

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,3 @@
+export const SWITCH_THEME = 'SWITCH_THEME';
+
+export default SWITCH_THEME;

--- a/src/app/views/page/ConnectedPage.tsx
+++ b/src/app/views/page/ConnectedPage.tsx
@@ -1,11 +1,15 @@
+/* istanbul ignore file */
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { useParams } from 'react-router-dom';
+import { ThemeType } from 'common/interfaces';
+import { switchTheme } from 'app/actions';
 import { fetchPage, PageActionTypes, resetPage } from './actions';
 import Page, { IProps } from './Page';
 
 const mapStateToProps = (state: any) => ({
+  currentTheme: state.appState.currentTheme,
   error: state.pageState.error,
   pending: state.pageState.pending,
   page: state.pageState.page,
@@ -16,7 +20,10 @@ export const mapDispatchToProps = (dispatch: Dispatch<PageActionTypes>) => ({
     dispatch<any>(fetchPage(slug))
   },
   resetPage: (): void => {
-    dispatch(resetPage())
+    dispatch<any>(resetPage())
+  },
+  switchTheme: (theme: ThemeType): void => {
+    dispatch<any>(switchTheme(theme))
   },
 });
 

--- a/src/app/views/page/Page.css.tsx
+++ b/src/app/views/page/Page.css.tsx
@@ -2,13 +2,13 @@ import styled, { css } from 'styled-components';
 import {
   animationCurve,
   boxShadow,
-  colours,
   layers,
   media
 } from 'app/styles';
 import { Footer } from 'app/components/footer/Footer';
 import { Loading } from 'app/components/loading/Loading';
 import { MenuButton } from 'app/components/menubutton/MenuButton';
+import { Toggle } from 'app/components/toggle/Toggle';
 
 interface ISideStProps {
   revealed: boolean,
@@ -60,7 +60,7 @@ export const SideSt = styled.aside<ISideStProps>`
   right: 0;
   width: 100vw;
   height: 100vh;
-  background-color: ${colours.secondary};
+  background: ${props => props?.theme?.colours?.secondary};
   box-shadow: none;
   transition: transform 0.5s ${animationCurve};
 
@@ -113,6 +113,11 @@ export const ErrorSt = styled.div`
 
 export const LoadingSt = styled(Loading)`
   grid-area: main;
+`;
+
+export const ToggleSt = styled(Toggle)`
+  margin-top: 2rem;
+  margin-left: 0.25rem;
 `;
 
 

--- a/src/app/views/page/Page.spec.tsx
+++ b/src/app/views/page/Page.spec.tsx
@@ -4,10 +4,12 @@ import { fireEvent, screen } from '@testing-library/react';
 import 'jest-styled-components';
 import { renderWithRouter } from 'common/utils/testutils';
 import * as utils from 'common/utils/utils';
+import { ThemeType } from 'common/interfaces';
 import Page, { IProps } from './Page';
 
 const noop = (): void => {};
 const defaultProps: IProps = {
+  currentTheme: ThemeType.DAY,
   error: null,
   pending: false,
   page: {
@@ -19,6 +21,7 @@ const defaultProps: IProps = {
   slug: 'test-page',
   fetchPage: noop,
   resetPage: noop,
+  switchTheme: noop,
 };
 
 describe('Page tests', () => {
@@ -119,6 +122,36 @@ describe('Page tests', () => {
 
     expect(container).toBeTruthy();
     expect(screen.getByText('Test heading')).toBeTruthy();
+  });
+
+  it('switches to the night theme', async () => {
+    const spySwitchTheme = jest.fn();
+    const container = renderWithRouter(
+      <Page {...defaultProps} switchTheme={spySwitchTheme} />
+    );
+    const toggle = container.getByTestId('toggle');
+
+    act((): void => {
+      fireEvent.click(toggle);
+    });
+    await expect(spySwitchTheme).toHaveBeenCalledWith(ThemeType.NIGHT);
+  });
+
+  it('switches to the day theme', async () => {
+    const spySwitchTheme = jest.fn();
+    const container = renderWithRouter(
+      <Page
+        {...defaultProps}
+        currentTheme={ThemeType.NIGHT}
+        switchTheme={spySwitchTheme}
+      />
+    );
+    const toggle = container.getByTestId('toggle');
+
+    act((): void => {
+      fireEvent.click(toggle);
+    });
+    await expect(spySwitchTheme).toHaveBeenCalledWith(ThemeType.DAY);
   });
 
   it('renders an error message', () => {

--- a/src/app/views/page/Page.tsx
+++ b/src/app/views/page/Page.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Meta } from 'app/components/meta/Meta';
 import { setBodyOverflow } from 'common/utils';
-import { IContentItem, IPage } from 'common/interfaces';
+import { IContentItem, IPage, ToggleValue, ThemeType } from 'common/interfaces';
 import { ContentItem } from 'app/components/contentItem/ContentItem';
 import { Nav } from 'app/components/nav/Nav';
 import {
@@ -13,15 +13,18 @@ import {
   PageSt,
   SideContainerSt,
   SideSt,
+  ToggleSt,
 } from './Page.css';
 
 export interface IProps {
+  currentTheme: ThemeType,
   error: any,
   pending: boolean,
   page: IPage,
   slug: string,
   fetchPage(slug: string): void,
   resetPage(): void,
+  switchTheme(theme: ThemeType): void,
 };
 
 const pageContents = ({ contents }: IPage): JSX.Element[] =>
@@ -32,12 +35,14 @@ const pageContents = ({ contents }: IPage): JSX.Element[] =>
 const errorMessage = (error: any): JSX.Element => <ErrorSt>{error.toString()}</ErrorSt>;
 
 const Page = ({
+  currentTheme,
   error,
   pending,
   page,
   slug,
   fetchPage,
   resetPage,
+  switchTheme,
 }: IProps): JSX.Element => {
   const [showMenu, setShowMenu] = useState<boolean>(false);
 
@@ -50,6 +55,14 @@ const Page = ({
     setShowMenu(false);
     document.body.style.overflow = 'auto';
   };
+
+  const toggleTheme = (toggleValue: ToggleValue): void => {
+    if (toggleValue === ToggleValue.ON) {
+      switchTheme(ThemeType.NIGHT);
+    } else {
+      switchTheme(ThemeType.DAY);
+    }
+  }
 
   useEffect((): any => {
     setShowMenu(false);
@@ -65,6 +78,11 @@ const Page = ({
         <SideSt revealed={showMenu} onClick={hideMenu}>
           <SideContainerSt>
             <Nav />
+            <ToggleSt
+              data-testid="toggle"
+              value={currentTheme === ThemeType.DAY ? ToggleValue.OFF : ToggleValue.ON}
+              onToggle={toggleTheme}
+            />
           </SideContainerSt>
         </SideSt>
         {

--- a/src/common/interfaces/enums.ts
+++ b/src/common/interfaces/enums.ts
@@ -1,0 +1,9 @@
+export enum ThemeType {
+  DAY = 'day',
+  NIGHT = 'night',
+}
+
+export enum ToggleValue {
+  ON = 'on',
+  OFF = 'off',
+}

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -2,3 +2,4 @@
 export * from './models';
 export * from './types';
 export * from './reduxStates';
+export * from './enums';

--- a/src/common/interfaces/reduxStates.ts
+++ b/src/common/interfaces/reduxStates.ts
@@ -1,4 +1,4 @@
-import { IPage } from 'common/interfaces';
+import { IPage, ThemeType } from 'common/interfaces';
 
 export interface IAction {
   error?: any,
@@ -10,4 +10,8 @@ export interface IPageState {
   error: any,
   pending: boolean,
   page?: IPage,
+}
+
+export interface IAppState {
+  currentTheme: ThemeType
 }

--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -1,9 +1,11 @@
 /* istanbul ignore file */
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import { appState } from 'app/reducer';
 import { pageState } from 'app/views/page/reducer';
 
 const rootReducer = combineReducers({
+  appState,
   pageState,
 });
 

--- a/src/common/utils/testutils.tsx
+++ b/src/common/utils/testutils.tsx
@@ -6,18 +6,21 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { IPageState } from 'common/interfaces';
+import { IAppState, IPageState } from 'common/interfaces';
 import { defaultState as pageDefaultState } from 'app/views/page/reducer'
+import { defaultState as appDefaultState } from 'app/reducer';
 
-interface IAppState {
+interface ICombinedState {
   pageState?: IPageState,
+  appState?: IAppState,
 };
 
-export const defaultAppState: IAppState = {
-  pageState: pageDefaultState
+export const defaultAppState: ICombinedState = {
+  pageState: pageDefaultState,
+  appState: appDefaultState,
 };
 
-export const createMockStore = (state: IAppState = defaultAppState): Store => {
+export const createMockStore = (state: ICombinedState = defaultAppState): Store => {
   const middlewares = [thunk];
   const mockStore = configureMockStore(middlewares);
 


### PR DESCRIPTION
#### What is this?
This PR adds support for [styled components theming](https://styled-components.com/docs/advanced#theming), and demonstrates the use of these with a toggle switch that changes the styling of the site between day and night mode (flips the colours.

Other changes also include some tweaks to the Footer SVG, so that the correct themed styling could be applied to it.