### PR TITLE
fix: offline caching now fixed and working

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,5 +24,5 @@ We should have the basic files in place before we install any dependencies
 - use Redux Saga
 - use Storybook for component rendering/documentation
 - production bundling and CI flow
-- error boundary for better error handlind
-- animated UI to communicate flow effectively to the user 
+- error boundary for better error handling
+- animated UI to communicate flow effectively to the user

--- a/assets/metadata/manifest.json
+++ b/assets/metadata/manifest.json
@@ -39,9 +39,9 @@
       "type": "image/png"
     }
   ],
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#ecedef",
-  "theme_color": "#d1e6c9"
+  "theme_color": "#ecedef"
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     _HELMET_
-
     <style type="text/css"></style>
     <script>BASE_URL</script>
   </head>
@@ -16,7 +15,7 @@
         window.addEventListener('load', () => {
           navigator
             .serviceWorker
-            .register('/worker.bundle.js')
+            .register('/worker.js')
             .then(registration => {
               console.log('Worker registration succeeded', registration.scope);
             }, error => {

--- a/src/app/components/menubutton/MenuButton.tsx
+++ b/src/app/components/menubutton/MenuButton.tsx
@@ -8,7 +8,7 @@ export interface IProps {
 }
 
 export const MenuButton = ({ className, onClick, navRevealed }: IProps): JSX.Element => (
-  <MenuButtonSt data-testid="menubutton" className={className} onClick={onClick}>
+  <MenuButtonSt aria-label="Menu" data-testid="menubutton" className={className} onClick={onClick}>
     <LineSt placement={LinePlacement.TOP} revealed={navRevealed} />
     <LineSt placement={LinePlacement.MIDDLE} revealed={navRevealed} />
     <LineSt placement={LinePlacement.BOTTOM} revealed={navRevealed} />

--- a/src/app/components/meta/Meta.tsx
+++ b/src/app/components/meta/Meta.tsx
@@ -17,6 +17,7 @@ export const Meta = ({ description, title, slug = '' }: IProps): JSX.Element => 
     <meta name="description" content={description} />
     <meta name="author" content="Matt Finucane" />
     <link rel="canonical" href={`${config.baseUrl}/${slug}`} />
+    <link rel="manifest" href="/manifest.json" />
 
     <meta property="og:url" content={`${config.baseUrl}/${slug}`} />
     <meta property="og:site_name" content="mattfinucane.com" />
@@ -32,6 +33,7 @@ export const Meta = ({ description, title, slug = '' }: IProps): JSX.Element => 
     <meta name="twitter:description" content={description} />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/images/icons/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="/images/icons/logo-32.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="/images/icons/logo-32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/images/icons/logo-128.png" sizes="128x128" />
     <link rel="icon" type="image/png" href="/images/icons/logo-192.png" sizes="192x192" />

--- a/src/app/components/toggle/Toggle.tsx
+++ b/src/app/components/toggle/Toggle.tsx
@@ -15,6 +15,7 @@ export const Toggle = ({ className, value, onToggle }: IProps): JSX.Element => {
 
   return (
     <ToggleTrackSt
+      aria-label="Light / Dark theme toggle"
       className={className}
       data-testid="toggle"
       onClick={onToggleTrackClick}

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -1,37 +1,54 @@
-import { apiCall } from 'common/utils';
 import config from 'common/config';
 
 declare const self: ServiceWorkerGlobalScope;
 
 const { appIconSizes, cacheName } = config;
-const appIconPaths: string[] = appIconSizes.map((size: number) => `images/icons/logo-${size}.png`);
+const appIconPaths: string[] = appIconSizes.map((size: number) => `/images/icons/logo-${size}.png`);
 const urlsToCache = [
-  '/',
-  'meta/manifest.json',
-  'main.bundle.js',
-  'worker.bundle.js',
+  '/manifest.json',
+  '/scripts/main.bundle.js',
+  '/scripts/vendors~main.bundle.js',
+  '/scripts/worker.bundle.js',
   ...appIconPaths,
 ];
 
-const fetchStoryUrls = async (): Promise<string[]> => {
-  try {
-    const response = await apiCall('/content/stories');
-    const data = await response.json();
-    const urls = data.map(({ slug }: any): string => `/story/${slug}`);
+const onActivate = (event: ExtendableEvent): void => {
+  const cacheWhitelist = [cacheName];
+  const clearCaches = (): Promise<void | boolean[]> => (
+    caches
+      .keys()
+      .then((cacheNames: any[]) => Promise.all(
+        cacheNames.map((name: string): Promise<boolean> => {
+          if (!cacheWhitelist.includes(name)) {
+            return caches.delete(name);
+          }
+          return Promise.resolve(false);
+        }),
+      ))
+  );
 
-    return Promise.resolve(urls);
-  } catch (error) {
-    return Promise.resolve([]);
-  }
+  event.waitUntil([
+    clearCaches,
+    self.clients.claim(),
+  ]);
 };
 
 const onInstall = (event: ExtendableEvent): void => {
   const preCache = async () => {
     const cache = await caches.open(cacheName);
-    const storyUrls = await fetchStoryUrls();
+    const pageUrls = [
+      '/', '/cv', '/projects', '/now',
+    ];
+    const pageSlugs = [
+      'home', 'cv', 'projects', 'now',
+    ];
 
     return cache.addAll(
-      [...urlsToCache, ...storyUrls],
+      [
+        ...urlsToCache,
+        ...pageUrls,
+        ...pageSlugs.map((slug: string) => `/content/page/${slug}`),
+      ],
     );
   };
 
@@ -46,23 +63,6 @@ const onFetch = (event: FetchEvent): void => {
   );
 };
 
-const onActivate = (event: ExtendableEvent): void => {
-  const cacheWhitelist = [cacheName];
-
-  event.waitUntil(
-    caches
-      .keys()
-      .then((cacheNames: any[]) => Promise.all(
-        cacheNames.map((name: string): Promise<boolean> => {
-          if (!cacheWhitelist.includes(name)) {
-            return caches.delete(name);
-          }
-          return Promise.resolve(false);
-        }),
-      )),
-  );
-};
-
-self.addEventListener('install', onInstall);
 self.addEventListener('activate', onActivate);
 self.addEventListener('fetch', onFetch);
+self.addEventListener('install', onInstall);

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,20 +1,24 @@
 /* istanbul ignore file */
 import { IAppConfig } from 'common/interfaces';
 
-const getConfig = (key: string): string | undefined => {
-  if (process?.browser) {
+export const getConfig = (key: string, fallback: string): string | undefined => {
+  if (typeof process !== 'undefined' && process?.env[key]) {
+    return process?.env[key];
+  }
+
+  if (typeof window !== 'undefined' && window[key]) {
     return window[key];
   }
 
-  return process.env[key];
+  return fallback;
 };
 
 export const config = {
-  baseUrl: getConfig('BASE_URL') || 'http://localhost',
-  port: getConfig('PORT') || '3000',
-  cacheName: getConfig('CACHE_NAME') || 'mattfinucane.com',
-  enableCache: Boolean(process?.env?.enableCache),
-  appIconSizes: [48, 72, 96, 144, 168, 192],
+  baseUrl: getConfig('BASE_URL', 'http://localhost'),
+  port: getConfig('PORT', '3000'),
+  cacheName: getConfig('CACHE_NAME', 'mattfinucane.com'),
+  enableCache: Boolean(process?.env?.ENABLE_CACHE),
+  appIconSizes: [32, 48, 72, 96, 128, 144, 168, 192, 196, 512],
 } as IAppConfig;
 
 export default config;

--- a/src/server/controllers/AssetsController.spec.ts
+++ b/src/server/controllers/AssetsController.spec.ts
@@ -11,9 +11,10 @@ describe('AssetsController tests', () => {
 
     await new AssetsController();
 
-    expect(spyUse).toHaveBeenCalledTimes(3);
+    expect(spyUse).toHaveBeenCalledTimes(4);
     expect(spyUse.mock.calls[0][0]).toEqual('/scripts');
     expect(spyUse.mock.calls[1][0]).toEqual('/images');
-    expect(spyUse.mock.calls[2][0]).toEqual('/meta');
+    expect(spyUse.mock.calls[2][0]).toEqual('/manifest.json');
+    expect(spyUse.mock.calls[3][0]).toEqual('/worker.js');
   });
 });

--- a/src/server/controllers/AssetsController.ts
+++ b/src/server/controllers/AssetsController.ts
@@ -19,7 +19,8 @@ class AssetsController implements IBaseController {
   initRoutes = () => {
     this.router.use('/scripts', expressStatic(`${this.distAppFilePath}/app`));
     this.router.use('/images', expressStatic(`${this.assetsFilePath}/images`));
-    this.router.use('/meta', expressStatic(`${this.assetsFilePath}/metadata`));
+    this.router.use('/manifest.json', expressStatic(`${this.assetsFilePath}/metadata/manifest.json`));
+    this.router.use('/worker.js', expressStatic(`${this.distAppFilePath}/app/worker.bundle.js`));
   }
 }
 

--- a/src/server/controllers/SSRController.tsx
+++ b/src/server/controllers/SSRController.tsx
@@ -91,9 +91,6 @@ class SSRController implements IBaseController {
           '<script>BASE_URL</script>',
           `<script type="text/javascript">window.BASE_URL = '${baseUrl}';</script>`,
         ).replace(
-          '<script>CLIENT</script>',
-          `<script type="text/javascript">window.CLIENT = true;</script>`,
-        ).replace(
           '_HELMET_',
           `
             ${helmet.title.toString()}


### PR DESCRIPTION
#### What is this?
This PR adds PWA (progressive web app) functionality and restores the service worker to a working state. This means we can cache the site (content and assets) for offline reading.

Other changes include:
- updates to the app manifest.json
- improved ways to get app config, differentiating between server and client
- added aria-labels to the menu button and theme toggle

Result: Significantly improved lighthouse scores.