### PR TITLE
fix(utils): correct regex and remove groupings (to support Firefox)

### DIFF
--- a/src/app/components/toggle/Toggle.css.tsx
+++ b/src/app/components/toggle/Toggle.css.tsx
@@ -23,7 +23,7 @@ export const ToggleTrackSt = styled.div`
 
   &::before {
     ${iconStyle};
-    left: 0.125rem;
+    left: 0;
     content: "☀️";
   }
 

--- a/src/app/views/page/Page.css.tsx
+++ b/src/app/views/page/Page.css.tsx
@@ -99,7 +99,7 @@ export const BurgerSt = styled(MenuButton)`
   z-index: ${layers.top};
   position: fixed;
   top: 0.5rem;
-  right: 0.5rem;
+  right: 1rem;
   width: 3rem;
   height: 3rem;
 

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -38,7 +38,7 @@ export const isExternalUrl = (url: string): boolean => {
 };
 
 export const toLinkObject = (linkText: string): ILink => {
-  const regexp: RegExp = /\[(?<text>.*?)\]\((?<url>.*?)("(?<title>.*?)")?\)/gm;
+  const regexp: RegExp = /\[(.*?)\]\((.*?)("(.*?)")?\)/gm;
   const result: any = regexp.exec(linkText);
 
   if (!result) {
@@ -49,12 +49,14 @@ export const toLinkObject = (linkText: string): ILink => {
     };
   }
 
+  const [, text, url, , title] = result;
+
   return {
-    text: result?.groups?.text,
-    ...(result.groups.title && { title: result.groups.title }),
-    url: result?.groups?.url.trim(),
+    text,
+    title,
+    url: url.trim(),
   };
-}
+};
 
 export const splitContent = (text: string): string[] => {
   const regexp: RegExp = /(\[.*?\]\(.*?\))/gm;


### PR DESCRIPTION
#### What is this?
This PR fixes an issue with Firefox and removes the grouping specifiers for the regex to split out the contents of a regex matcher as grouped items.

Since Firefox does not support this feature, we needed to roll back and extract matched elements through the result array.

The theme toggle has also been tweaked to work better in Safari and the menu burger has been budged over 8px from the right.