### PR TITLE
feat(docker): basic set up started to get working containers

### DIFF
--- a/.docker/nginx/Dockerfile
+++ b/.docker/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+RUN  rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -1,0 +1,51 @@
+events {
+  worker_connections  4096;
+}
+
+http {
+  server {
+    listen 80;
+    server_name mattfinucane.build www.mattfinucane.build;
+    location / {
+      rewrite ^ https://$server_name$request_uri permanent;
+    }
+  }
+
+  server {
+    listen 443 ssl http2;
+
+    server_name mattfinucane.build;
+
+    ssl_certificate       /etc/ssl/mattfinucane.build/server.crt;
+    ssl_certificate_key   /etc/ssl/mattfinucane.build/server.key;
+    ssl_protocols         TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers           HIGH:!aNULL:!MD5;
+
+    gzip            on;
+    gzip_vary 		  on;
+    gzip_min_length 1024;
+    gzip_proxied 	  expired no-cache no-store private auth;
+    gzip_types
+      text/plain
+      text/html
+      text/css
+      text/xml
+      text/x-component
+      application/javascript
+      application/json
+      application/x-javascript
+      application/xml
+      image/svg+xml;
+
+    gzip_disable	"MSIE [1-6]\.";
+
+    location / {
+      proxy_pass          http://app:3001;
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection 'upgrade';
+      proxy_set_header    Host $host;
+      proxy_cache_bypass  $http_upgrade;
+    }
+  }
+}

--- a/.docker/node/Dockerfile
+++ b/.docker/node/Dockerfile
@@ -1,0 +1,10 @@
+FROM        node:14.3-alpine
+RUN         mkdir -p /opt/app/node_modules && chown -R node:node /opt/app
+USER        node
+WORKDIR     /opt/app
+COPY        package.json yarn.lock ./
+RUN         yarn cache clean
+RUN         yarn global add webpack webpack-cli node-dev
+RUN         yarn
+COPY        --chown=node:node . .
+RUN         yarn build

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+__mocks__
+.DS_Store
+.docker
+.git
+.gitignore
+coverage
+dist
+node_modules
+.dockerignore
+*.MD
+*.log
+**/*.spec.tsx
+**/*.spec.ts

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ We should have the basic files in place before we install any dependencies
 - code lint tools
 - basic REST server to serve assets and content
 - better path aliasing for module imports
-- implemented server side rendering
+- implement server side rendering
 - progressive web app with offline capability
 - improved Lighthouse audit scores
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+
+services:
+  app:
+    container_name: app
+    restart: on-failure
+    build:
+      context: .
+      dockerfile: .docker/node/Dockerfile
+    environment:
+      - API_URL=https://mattfinucane.build
+      - CANONICAL_URL=https://mattfinucane.build
+      - PORT=3001
+      - CACHE_NAME=mattfinucane.build
+      - ENABLE_CACHE=true
+    command: yarn server
+
+  nginx:
+    container_name: nginx
+    build:
+      context: .docker/nginx
+      dockerfile: Dockerfile
+    links:
+      - app
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ~/ssl/mattfinucane.build:/etc/ssl/mattfinucane.build/
+    command: nginx -g "daemon off;"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "server": "node-dev ./dist/server/server.js",
-    "webpack": "webpack --config webpack.dev.js --watch --progress --colors --open",
+    "dev": "webpack --config webpack.dev.js --watch --progress --colors --open",
     "clear": "rm -rf dist/app dist/server",
     "build": "webpack --config webpack.prod.js",
     "test": "jest",
@@ -58,11 +58,10 @@
     "ts-node": "^8.8.1",
     "typescript": "^3.8.3",
     "url-loader": "^4.1.0",
-    "webpack": "^4.41.6",
+    "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-merge": "^4.2.2",
-    "webpack-node-externals": "^1.7.2",
-    "webpack-visualizer-plugin": "^0.1.11"
+    "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
     "@types/express": "^4.17.3",

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8" />
     _HELMET_
     <style type="text/css"></style>
-    <script>BASE_URL</script>
+    <script>API_URL</script>
+    <script>CANONICAL_URL</script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/components/meta/Meta.spec.tsx
+++ b/src/app/components/meta/Meta.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { Helmet } from 'react-helmet';
+import { Helmet, HelmetData } from 'react-helmet';
 import { Meta, IProps } from './Meta';
 
 const defaultProps: IProps = {
@@ -11,7 +11,7 @@ const defaultProps: IProps = {
 describe('Meta tests', () => {
   it('renders the component', () => {
     const wrapper = render(<Meta {...defaultProps} />);
-    const helmet = Helmet.peek();
+    const helmet: HelmetData = Helmet.peek();
     const expectedMetaTags = [
       {
         name: 'viewport',
@@ -20,7 +20,7 @@ describe('Meta tests', () => {
       { name: 'theme-color', content: '#ecedef' },
       { name: 'description', content: 'Test description' },
       { name: 'author', content: 'Matt Finucane' },
-      { property: 'og:url', content: 'http://localhost/' },
+      { property: 'og:url', content: 'http://localhost:3000/' },
       { property: 'og:site_name', content: 'mattfinucane.com' },
       { property: 'og:type', content: 'website' },
       { property: 'og:locale', content: 'en-IE' },
@@ -29,7 +29,7 @@ describe('Meta tests', () => {
       { name: 'twitter:site', content: '@matfinucane' },
       { name: 'twitter:creator', content: '@matfinucane' },
       { name: 'twitter:title', content: 'Test title' },
-      { name: 'twitter:url', content: 'http://localhost/' },
+      { name: 'twitter:url', content: 'http://localhost:3000/' },
       { name: 'twitter:description', content: 'Test description' }
     ];
 
@@ -45,7 +45,7 @@ describe('Meta tests', () => {
     expect(wrapper).toBeTruthy();
     expect(helmet.metaTags[4]).toEqual({
       property: 'og:url',
-      content: 'http://localhost/test-slug'
+      content: 'http://localhost:3000/test-slug'
     });
   });
 });

--- a/src/app/components/meta/Meta.tsx
+++ b/src/app/components/meta/Meta.tsx
@@ -16,10 +16,10 @@ export const Meta = ({ description, title, slug = '' }: IProps): JSX.Element => 
     <meta name="theme-color" content={colours.secondary} />
     <meta name="description" content={description} />
     <meta name="author" content="Matt Finucane" />
-    <link rel="canonical" href={`${config.baseUrl}/${slug}`} />
+    <link rel="canonical" href={`${config.canonicalUrl}/${slug}`} />
     <link rel="manifest" href="/manifest.json" />
 
-    <meta property="og:url" content={`${config.baseUrl}/${slug}`} />
+    <meta property="og:url" content={`${config.canonicalUrl}/${slug}`} />
     <meta property="og:site_name" content="mattfinucane.com" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en-IE" />
@@ -29,7 +29,7 @@ export const Meta = ({ description, title, slug = '' }: IProps): JSX.Element => 
     <meta name="twitter:site" content="@matfinucane" />
     <meta name="twitter:creator" content="@matfinucane" />
     <meta name="twitter:title" content={title} />
-    <meta name="twitter:url" content={`${config.baseUrl}/${slug}`} />
+    <meta name="twitter:url" content={`${config.canonicalUrl}/${slug}`} />
     <meta name="twitter:description" content={description} />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/images/icons/apple-touch-icon.png" />

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -14,7 +14,8 @@ export const getConfig = (key: string, fallback: string): string | undefined => 
 };
 
 export const config = {
-  baseUrl: getConfig('BASE_URL', 'http://localhost'),
+  apiUrl: getConfig('API_URL', 'http://localhost:3000'),
+  canonicalUrl: getConfig('CANONICAL_URL', 'http://localhost:3000'),
   port: getConfig('PORT', '3000'),
   cacheName: getConfig('CACHE_NAME', 'mattfinucane.com'),
   enableCache: Boolean(process?.env?.ENABLE_CACHE),

--- a/src/common/interfaces/models.ts
+++ b/src/common/interfaces/models.ts
@@ -1,6 +1,7 @@
 export interface IAppConfig {
+  readonly apiUrl: string;
+  readonly canonicalUrl: string;
   readonly appIconSizes: number[];
-  readonly baseUrl: string;
   readonly cacheName: string;
   readonly port: string;
   enableCache: boolean;

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -1,10 +1,11 @@
 import fetch, { RequestInit, Response } from 'node-fetch';
 import config from 'common/config';
 
-export const apiCall = async (url: string, options: RequestInit = { method: 'GET' }): Promise<any> => {
-  const { baseUrl, port } = config;
+export const apiCall = async (resource: string, options: RequestInit = { method: 'GET' }): Promise<any> => {
+  const { apiUrl } = config;
+  const url = `${apiUrl}${resource}`;
 
-  return await fetch(`${baseUrl}:${port}${url}`, options) as Response;
+  return await fetch(url, options) as Response;
 };
 
 export default apiCall;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3,7 +3,6 @@ import config from 'common/config';
 import { IBaseController } from 'server/interfaces';
 
 interface IApp {
-  baseUrl: string;
   port: string;
   controllers: IBaseController[];
 }
@@ -13,11 +12,8 @@ class App {
 
   public port: string;
 
-  public baseUrl: string;
-
-  constructor({ controllers, baseUrl, port }: IApp) {
+  constructor({ controllers, port }: IApp) {
     this.app = express();
-    this.baseUrl = baseUrl;
     this.port = port;
     this.setupRoutes(controllers);
   }
@@ -31,7 +27,7 @@ class App {
   public listen() {
     this.app.listen(this.port, () => {
       // eslint-disable-next-line no-console
-      console.log(`App listening on ${this.baseUrl}:${this.port} with service worker caching ${config.enableCache ? 'enabled' : 'disabled'}`);
+      console.log(`App listening on ${this.port} with service worker caching ${config.enableCache ? 'enabled' : 'disabled'}`);
     });
   }
 }

--- a/src/server/controllers/SSRController.tsx
+++ b/src/server/controllers/SSRController.tsx
@@ -42,7 +42,7 @@ class SSRController implements IBaseController {
     const preloadedState: any = this.store.getState();
     const indexPath: string = `${this.baseFilePath}/index.html`;
     const preloadedStateJson: string = JSON.stringify(preloadedState).replace(/</g, '\\u003c');
-    const { enableCache, baseUrl } = config;
+    const { apiUrl, canonicalUrl, enableCache } = config;
     let reactAppHtml: string;
     let styleTags: string;
     let helmet: HelmetData;
@@ -88,8 +88,11 @@ class SSRController implements IBaseController {
           'ENABLE_CACHE',
           enableCache ? 'true' : 'false'
         ).replace(
-          '<script>BASE_URL</script>',
-          `<script type="text/javascript">window.BASE_URL = '${baseUrl}';</script>`,
+          '<script>API_URL</script>',
+          `<script type="text/javascript">window.API_URL = '${apiUrl}';</script>`,
+        ).replace(
+          '<script>CANONICAL_URL</script>',
+          `<script type="text/javascript">window.CANONICAL_URL = '${canonicalUrl}';</script>`,
         ).replace(
           '_HELMET_',
           `

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,16 +4,15 @@ import ContentController from 'server/controllers/ContentController';
 import config from 'common/config';
 import App from './app';
 
-const { baseUrl, port } = config;
+const { port } = config;
 
 const app = new App({
-  baseUrl,
-  port,
   controllers: [
     new ContentController(),
     new AssetsController(),
     new SSRController(),
   ],
+  port,
 });
 
 app.listen();

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
-const Visuaulizer = require('webpack-visualizer-plugin');
 
 const common = {
   module: {
@@ -36,11 +35,6 @@ const client = {
     main: path.resolve(__dirname, 'src/app/index.tsx'),
     worker: path.resolve(__dirname, 'src/app/worker.ts'),
   },
-  plugins: [
-    new Visuaulizer({
-      filename: './stats.html',
-    }),
-  ],
   output: {
     path: path.resolve(__dirname, 'dist/app'),
     filename: '[name].bundle.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,11 +1734,6 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
-acorn@^5.2.1:
-  version "5.7.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
-  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
-
 acorn@^6.0.1, acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
@@ -1768,11 +1763,6 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 ansi-colors@^3.0.0:
   version "3.2.4"
@@ -1959,11 +1949,6 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -2002,11 +1987,6 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
-
-ast-types@0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
-  integrity sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -2165,11 +2145,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-base62@^1.1.0:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/base62/-/base62-1.2.8.tgz#1264cb0fb848d875792877479dbe8bae6bae3428"
-  integrity sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -2730,7 +2705,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.20.0, commander@^2.5.0:
+commander@^2.11.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2744,21 +2719,6 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-
-commoner@^0.10.1:
-  version "0.10.8"
-  resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
-  integrity sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=
-  dependencies:
-    commander "^2.5.0"
-    detective "^4.3.1"
-    glob "^5.0.15"
-    graceful-fs "^4.1.2"
-    iconv-lite "^0.4.5"
-    mkdirp "^0.5.0"
-    private "^0.1.6"
-    q "^1.1.2"
-    recast "^0.11.17"
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -2883,11 +2843,6 @@ core-js-pure@^3.0.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
-
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3045,11 +3000,6 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-d3@^3.5.6:
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-3.5.17.tgz#bc46748004378b21a360c9fc7cf5231790762fb8"
-  integrity sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=
-
 damerau-levenshtein@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
@@ -3182,11 +3132,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-defined@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
-
 del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
@@ -3237,14 +3182,6 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
-
-detective@^4.3.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.1.tgz#0eca7314338442febb6d65da54c10bb1c82b246e"
-  integrity sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==
-  dependencies:
-    acorn "^5.2.1"
-    defined "^1.0.0"
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -3480,14 +3417,6 @@ entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
   integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
-
-envify@^3.0.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/envify/-/envify-3.4.1.tgz#d7122329e8df1688ba771b12501917c9ce5cbce8"
-  integrity sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=
-  dependencies:
-    jstransform "^11.0.3"
-    through "~2.3.4"
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -3744,20 +3673,10 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-esprima-fb@^15001.1.0-dev-harmony-fb:
-  version "15001.1.0-dev-harmony-fb"
-  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz#30a947303c6b8d5e955bee2b99b1d233206a6901"
-  integrity sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=
-
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
-  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
 esquery@^1.0.1:
   version "1.3.1"
@@ -4039,17 +3958,6 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
-
-fbjs@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.6.1.tgz#9636b7705f5ba9684d44b72f78321254afc860f7"
-  integrity sha1-lja3cF9bqWhNRLcveDISVK/IYPc=
-  dependencies:
-    core-js "^1.0.0"
-    loose-envify "^1.0.0"
-    promise "^7.0.3"
-    ua-parser-js "^0.7.9"
-    whatwg-fetch "^0.9.0"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -4356,17 +4264,6 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
-
-glob@^5.0.15:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
@@ -4734,7 +4631,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.5:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5767,17 +5664,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jstransform@^11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/jstransform/-/jstransform-11.0.3.tgz#09a78993e0ae4d4ef4487f6155a91f6190cb4223"
-  integrity sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=
-  dependencies:
-    base62 "^1.1.0"
-    commoner "^0.10.1"
-    esprima-fb "^15001.1.0-dev-harmony-fb"
-    object-assign "^2.0.0"
-    source-map "^0.4.2"
-
 jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
@@ -6289,7 +6175,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.4:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6338,7 +6224,7 @@ mkdirp@1.x:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
+mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -6585,11 +6471,6 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
-object-assign@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
-  integrity sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -7212,7 +7093,7 @@ pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.4.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-private@^0.1.6, private@^0.1.8, private@~0.1.5:
+private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -7236,13 +7117,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise@^7.0.3:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
 
 prompts@^2.0.1:
   version "2.3.2"
@@ -7336,11 +7210,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@^1.1.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -7400,11 +7269,6 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-react-dom@^0.14.0:
-  version "0.14.9"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.14.9.tgz#05064a3dcf0fb1880a3b2bfc9d58c55d8d9f6293"
-  integrity sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM=
 
 react-dom@^16.13.0:
   version "16.13.1"
@@ -7480,14 +7344,6 @@ react-side-effect@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
   integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
-
-react@^0.14.0:
-  version "0.14.9"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.14.9.tgz#9110a6497c49d44ba1c0edd317aec29c2e0d91d1"
-  integrity sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=
-  dependencies:
-    envify "^3.0.0"
-    fbjs "^0.6.1"
 
 react@^16.13.0:
   version "16.13.1"
@@ -7586,16 +7442,6 @@ realpath-native@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-2.0.0.tgz#7377ac429b6e1fd599dc38d08ed942d0d7beb866"
   integrity sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==
-
-recast@^0.11.17:
-  version "0.11.23"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
-  integrity sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=
-  dependencies:
-    ast-types "0.9.6"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -8321,14 +8167,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
-  dependencies:
-    amdefine ">=0.0.4"
-
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.0:
+source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -8904,7 +8743,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.6, through@~2.3.4:
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -9147,11 +8986,6 @@ typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-ua-parser-js@^0.7.9:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
 unherit@^1.0.4:
   version "1.1.3"
@@ -9571,17 +9405,7 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-visualizer-plugin@^0.1.11:
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/webpack-visualizer-plugin/-/webpack-visualizer-plugin-0.1.11.tgz#b8770ad86b4f652612c68b1b782253faf9f8a34e"
-  integrity sha1-uHcK2GtPZSYSxosbeCJT+vn4o04=
-  dependencies:
-    d3 "^3.5.6"
-    mkdirp "^0.5.1"
-    react "^0.14.0"
-    react-dom "^0.14.0"
-
-webpack@^4.41.6:
+webpack@^4.43.0:
   version "4.43.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
   integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
@@ -9630,11 +9454,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
-  integrity sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
#### What is this?
This is the first building block of a deployment set up I am experimenting with, where I will use Docker and Docker Hub to handle deployments.

With this, I have a fully working Docker Compose set up so I can run the Node server that serves up the client side Javascript.

**Note:** I am *not* using Docker for local development. I have tried that before and it's too cumbersome and doesn't tie in well with this particular project.

Alongside this, I have a working reverse proxy with nginx and an experimental self-signed SSL cert set up [(see this excellent guide)](https://www.freecodecamp.org/news/how-to-get-https-working-on-your-local-development-environment-in-5-minutes-7af615770eec/).

This helps a lot because it enables me to build the site as close to production as I can get, and adds support for nice things like https, http2 and gzip compression. All these things facilitate nice Lighthouse scores relating to performance.

#### Other changes
- the webpack visualiser plugin was showing deprecation warnings, so I have removed it.
- the config set up for the BASE_URL has been improved and we are now using a new API_URL config parameter.