### PR TITLE
feat(docker): set up production configuration for nginx

### DIFF
--- a/.docker/nginx/Dockerfile
+++ b/.docker/nginx/Dockerfile
@@ -1,3 +1,3 @@
 FROM nginx:alpine
 RUN  rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY templates/nginx.conf.template /etc/nginx/templates/nginx.conf.template

--- a/.docker/nginx/templates/nginx.conf.template
+++ b/.docker/nginx/templates/nginx.conf.template
@@ -5,7 +5,14 @@ events {
 http {
   server {
     listen 80;
-    server_name mattfinucane.build www.mattfinucane.build;
+    server_name mattfinucane.ie mattfinucane.eu;
+    return 301 https://${NGINX_HOST};
+  }
+
+  server {
+    listen 80;
+    server_name ${NGINX_HOST} www.${NGINX_HOST};
+
     location / {
       rewrite ^ https://$server_name$request_uri permanent;
     }
@@ -14,10 +21,10 @@ http {
   server {
     listen 443 ssl http2;
 
-    server_name mattfinucane.build;
+    server_name ${NGINX_HOST} www.${NGINX_HOST};
 
-    ssl_certificate       /etc/ssl/mattfinucane.build/server.crt;
-    ssl_certificate_key   /etc/ssl/mattfinucane.build/server.key;
+    ssl_certificate       /etc/letsencrypt/live/mattfinucane.com/${SSL_CERTIFICATE};
+    ssl_certificate_key   /etc/letsencrypt/live/mattfinucane.com/${SSL_CERTIFICATE_KEY};
     ssl_protocols         TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers           HIGH:!aNULL:!MD5;
 
@@ -38,7 +45,7 @@ http {
     gzip_disable	"MSIE [1-6]\.";
 
     location / {
-      proxy_pass          http://app:3001;
+      proxy_pass          http://app:${PROXY_APP_PORT};
       proxy_http_version  1.1;
       proxy_set_header    Upgrade $http_upgrade;
       proxy_set_header    Connection 'upgrade';

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  app:
+    environment:
+      - API_URL=https://mattfinucane.com
+      - CANONICAL_URL=https://mattfinucane.com
+      - CACHE_NAME=mattfinucane.com
+
+  nginx:
+    environment:
+      - NGINX_HOST=mattfinucane.com
+      - SSL_CERTIFICATE=fullchain.pem
+      - SSL_CERTIFICATE_KEY=privkey.pem
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   app:
     container_name: app
+    image: matfin/personal-website-app:latest
     restart: on-failure
     build:
       context: .
@@ -17,14 +18,21 @@ services:
 
   nginx:
     container_name: nginx
+    image: matfin/personal-website-nginx:latest
     build:
       context: .docker/nginx
       dockerfile: Dockerfile
+    environment:
+      - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
+      - NGINX_HOST=mattfinucane.build
+      - SSL_CERTIFICATE=server.crt
+      - SSL_CERTIFICATE_KEY=server.key
+      - PROXY_APP_PORT=3001
     links:
       - app
     ports:
       - "80:80"
       - "443:443"
     volumes:
-      - ~/ssl/mattfinucane.build:/etc/ssl/mattfinucane.build/
+      - ~/ssl/letsencrypt:/etc/letsencrypt:ro
     command: nginx -g "daemon off;"


### PR DESCRIPTION
#### What is this?
This PR alters the docker set up and adds an extra compose file for production configurations. This is set up in order to make it easier to create images and containers remotely.

#### How does it work?
- I followed [this guide](https://www.freecodecamp.org/news/how-to-get-https-working-on-your-local-development-environment-in-5-minutes-7af615770eec/) to get some self signed certs set up for my local build environment, so that I could use https locally.
- I then followed [this DigitalOcean guide](https://www.digitalocean.com/community/tutorials/how-to-use-certbot-standalone-mode-to-retrieve-let-s-encrypt-ssl-certificates-on-ubuntu-1804) to set up my SSL certs on the remote production server.
- My `docker-compose.yml` and `docker-compose.prod.yml` files have settings for which certificates nginx should use for SSL (https and http2). The `volumes` definition also point to where the certs are located.
- With that, I can get my local build environment running as well as the production environment, and I don't need to maintain separate config files for different environments. I can specify a chain of docker compose files so override settings in the previous one.

#### Challenges
- Docker was quite tricky to get working, especially with nginx and ssl certs for https. I wanted to map volumes to the `/etc/letsencrypt/live/mattfinucane.com/` directory, so I could load these SSL certs from the host without needing to copy them into the container. This didn't work very well, because I was accessing a symlink to a file that existed outside the container, so they could not be found.
- I also ran into issues with nginx because I was trying to build with an nginx template file. This is all well and good when I run build locally, because the file is there in the source code, but doesn't work so well when building a container on the remote production server. To get around this, I copy the nginx template file into the container so it's there when the build happens remotely.