### PR TITLE
fix(utils): server side api calls should only use localhost

### DIFF
--- a/src/app/components/meta/Meta.spec.tsx
+++ b/src/app/components/meta/Meta.spec.tsx
@@ -14,6 +14,10 @@ describe('Meta tests', () => {
     const helmet: HelmetData = Helmet.peek();
     const expectedMetaTags = [
       {
+        name: 'apple-mobile-web-app-status-bar-style',
+        content: 'black-translucent',
+      },
+      {
         name: 'viewport',
         content: 'width=device-width, initial-scale=1, user-scalable=yes'
       },
@@ -43,7 +47,7 @@ describe('Meta tests', () => {
     const helmet = Helmet.peek();
 
     expect(wrapper).toBeTruthy();
-    expect(helmet.metaTags[4]).toEqual({
+    expect(helmet.metaTags[5]).toEqual({
       property: 'og:url',
       content: 'http://localhost:3000/test-slug'
     });

--- a/src/app/components/nav/Nav.css.tsx
+++ b/src/app/components/nav/Nav.css.tsx
@@ -14,6 +14,7 @@ export const NavSt = styled.nav`
 export const LinkSt = styled(Link)<ILinkStProps>`
   position: relative;
   flex: 0 1 3rem;
+  height: 3rem;
   display: flex;
   align-items: center;
   margin-top: 2rem;

--- a/src/common/interfaces/models.ts
+++ b/src/common/interfaces/models.ts
@@ -1,10 +1,10 @@
 export interface IAppConfig {
-  readonly apiUrl: string;
-  readonly canonicalUrl: string;
   readonly appIconSizes: number[];
+  readonly apiUrl: string;
   readonly cacheName: string;
-  readonly port: string;
+  readonly canonicalUrl: string;
   enableCache: boolean;
+  readonly port: string;
 }
 
 export type ContentTypes = IContentItem | ITopic | IPosition | IProject | string;

--- a/src/common/utils/api.spec.ts
+++ b/src/common/utils/api.spec.ts
@@ -1,21 +1,47 @@
-import fetch from 'node-fetch';
+import * as fetch from 'node-fetch';
+import * as utils from 'common/utils/utils';
 import apiCall from './api';
 
 const { Response } = jest.requireActual('node-fetch');
 
 jest.mock('node-fetch', () => jest.fn());
+jest.mock('common/config', () => ({
+  apiUrl: 'https://test.de',
+  port: 4000
+}));
 
-describe('api tests', () => {
-  it('calls fetch and resolved with a response', async () => {
+describe('api tests', (): void => {
+  it('calls fetch and resolved with a response', async (): Promise<void> => {
     const expectedResponse: string = JSON.stringify({ test: 'Works!' });
-
-    (fetch as jest.MockedFunction<typeof fetch>)
-      .mockResolvedValueOnce(new Response(expectedResponse));
-
+    const spyFetch = jest.spyOn(fetch, 'default').mockResolvedValue(new Response(expectedResponse));
     const response = await apiCall('/test/resource');
     const responseData = await response.json();
 
+    expect(spyFetch).toHaveBeenCalledWith(
+      'https://test.de/test/resource',
+      { method: 'GET'}
+    );
     expect(response.status).toEqual(200);
     expect(responseData).toEqual({ test: 'Works!' });
+
+    spyFetch.mockRestore();
+  });
+
+  it('calls fetch with a url when server side', async (): Promise<void> => {
+    const expectedResponse: string = JSON.stringify({ test: 'Works!' });
+    const spyFetch = jest.spyOn(fetch, 'default').mockResolvedValue(new Response(expectedResponse));
+    const spyIsServer = jest.spyOn(utils, 'isServer').mockImplementation(() => true);
+    const response = await apiCall('/test/resource');
+    const responseData = await response.json();
+
+    expect(spyFetch).toHaveBeenCalledWith(
+      'http://localhost:4000/test/resource',
+      { method: 'GET'}
+    );
+    expect(response.status).toEqual(200);
+    expect(responseData).toEqual({ test: 'Works!' });
+
+    spyFetch.mockRestore();
+    spyIsServer.mockRestore();
   });
 });

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -1,9 +1,11 @@
 import fetch, { RequestInit, Response } from 'node-fetch';
 import config from 'common/config';
+import { isServer } from 'common/utils';
 
 export const apiCall = async (resource: string, options: RequestInit = { method: 'GET' }): Promise<any> => {
-  const { apiUrl } = config;
-  const url = `${apiUrl}${resource}`;
+  const { apiUrl, port } = config;
+  const base = isServer() ? `http://localhost:${port}` : apiUrl;
+  const url = `${base}${resource}`;
 
   return await fetch(url, options) as Response;
 };

--- a/src/common/utils/templates.spec.ts
+++ b/src/common/utils/templates.spec.ts
@@ -1,6 +1,6 @@
 import { indexTemplate, IProps } from './templates';
 
-describe('indexTemplate tests', () => {
+describe('indexTemplate tests', (): void => {
   it('should render the correct html output', (): void => {
     const defaultProps: IProps = {
       apiUrl: 'https://test.ie',

--- a/src/common/utils/utils.spec.ts
+++ b/src/common/utils/utils.spec.ts
@@ -1,26 +1,26 @@
 import { formatDate, isLink, toLinkObject, splitContent } from './utils';
 import { utimes } from 'fs';
 
-describe('utils tests', () => {
-  it('should format a date', () => {
+describe('utils tests', (): void => {
+  it('should format a date', (): void => {
     expect(formatDate(new Date('1982-04-26'))).toEqual('April 1982');
   });
 
-  it('should check if a string is an MD formatted link', () => {
+  it('should check if a string is an MD formatted link', (): void => {
     expect(isLink('Nothing in here!')).toBe(false);
     expect(isLink()).toBe(false);
     expect(isLink('I like to code in Javascript (ES)')).toBe(false);
     expect(isLink('[page](https://www.test.dd)')).toBe(true);
   });
 
-  it('checks to see if a string contains a markdown flavoured link', () => {
+  it('checks to see if a string contains a markdown flavoured link', (): void => {
     expect(isLink('I am not a link!')).toBe(false);
     expect(isLink('I do indeed [have a link](/link "A link!") contained in me!')).toBe(true);
     expect(isLink('I am [a link](/a-link) with no title!')).toBe(true);
     expect(isLink('I am [a malformed] (/a-link) because of the space!')).toBe(false);
   });
 
-  it('converts a markdown style link to a link object', () => {
+  it('converts a markdown style link to a link object', (): void => {
     expect(
       toLinkObject('[test link with title](/test "Test")')
     ).toEqual({
@@ -45,7 +45,7 @@ describe('utils tests', () => {
     });
   });
 
-  it('splits out content if a markdown flavoured link is found', () => {
+  it('splits out content if a markdown flavoured link is found', (): void => {
     expect(
       splitContent('I am a normal parahraph with no links')
     ).toEqual([

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -63,3 +63,5 @@ export const splitContent = (text: string): string[] => {
 
   return text.split(regexp);
 };
+
+export const isServer = (): boolean => typeof window === 'undefined';

--- a/src/server/controllers/AssetsController.spec.ts
+++ b/src/server/controllers/AssetsController.spec.ts
@@ -1,8 +1,8 @@
 import express, { Router } from 'express';
 import AssetsController from './AssetsController';
 
-describe('AssetsController tests', () => {
-  it('should initialise routes', async () => {
+describe('AssetsController tests', (): void => {
+  it('should initialise routes', async (): Promise<void> => {
     const spyUse = jest.fn() as jest.MockedFunction<typeof Router>;
 
     jest.spyOn(express, 'Router').mockReturnValue({

--- a/src/server/controllers/ContentController.spec.ts
+++ b/src/server/controllers/ContentController.spec.ts
@@ -1,8 +1,8 @@
 import express, { Request, Response, Router } from 'express';
 import ContentController from './ContentController';
 
-describe('ContentController tests', () => {
-  it('should initialise routes', async () => {
+describe('ContentController tests', (): void => {
+  it('should initialise routes', async (): Promise<void> => {
     const spyGet = jest.fn() as jest.MockedFunction<typeof Router>;
 
     jest.spyOn(express, 'Router').mockReturnValue({

--- a/src/server/controllers/SSRController.spec.ts
+++ b/src/server/controllers/SSRController.spec.ts
@@ -8,7 +8,7 @@ import SSRController from './SSRController';
 import { Helmet } from 'react-helmet';
 
 jest.mock('common/store');
-jest.mock('common/config', () => ({
+jest.mock('common/config', (): any => ({
   enableCache: true,
 }));
 jest.mock('server/IndexComponent');
@@ -16,14 +16,7 @@ jest.mock('react-dom/server');
 
 Helmet.canUseDOM = false;
 
-const stripSpaces = (str: string): string => str.replace(/\s/g, '');
-
-const mockedHtml = `
-  <script>PRELOADED_STATE</script>
-  <script type="text/javascript">const enableServiceWorker = ENABLE_CACHE;</script>
-`;
-
-describe('SSRController tests', () => {
+describe('SSRController tests', (): void => {
   const spyDispatch = jest.fn();
   const spyGetState = jest.fn();
 
@@ -45,7 +38,7 @@ describe('SSRController tests', () => {
     config.mockReset();
   });
 
-  it('should initialise the routes and set up the redux store', async () => {
+  it('should initialise the routes and set up the redux store', async (): Promise<void> => {
     const spyGet = jest.fn() as jest.MockedFunction<typeof Router>;
 
     jest.spyOn(express, 'Router').mockReturnValue({
@@ -57,7 +50,7 @@ describe('SSRController tests', () => {
     expect(spyGet).toHaveBeenCalledWith('/:slug(projects|cv|now)?', expect.any(Function), expect.any(Function));
   });
 
-  it('should dispatch to fetch a page and call next', async () => {
+  it('should dispatch to fetch a page and call next', async (): Promise<void> => {
     const spyFetchStory = jest.spyOn(pageActions, 'fetchPage');
     const spyNext = jest.fn();
 
@@ -78,7 +71,7 @@ describe('SSRController tests', () => {
     spyFetchStory.mockReset();
   });
 
-  it('should dispatch to fetch home page by default and call next', async () => {
+  it('should dispatch to fetch home page by default and call next', async (): Promise<void> => {
     const spyFetchStory = jest.spyOn(pageActions, 'fetchPage');
     const spyNext = jest.fn();
 
@@ -95,7 +88,7 @@ describe('SSRController tests', () => {
     spyFetchStory.mockReset();
   });
 
-  it('should generate SSR content then send it', async () => {
+  it('should generate SSR content then send it', async (): Promise<void> => {
     const spySend = jest.fn();
     const spyStatus = jest.fn().mockReturnValue({
       send: spySend,
@@ -125,7 +118,7 @@ describe('SSRController tests', () => {
     spyGenerateSSRContent.mockReset();
   });
 
-  it('should send an error if content could not be generated', async () => {
+  it('should send an error if content could not be generated', async (): Promise<void> => {
     const spySend = jest.fn();
     const spyStatus = jest.fn().mockReturnValue({
       send: spySend,
@@ -150,7 +143,7 @@ describe('SSRController tests', () => {
     spyGenerateSSRContent.mockReset();
   });
 
-  it('generates SSR content', async() => {
+  it('generates SSR content', async(): Promise<void> => {
     const request = {
       params: {
         slug: 'test-slug'
@@ -174,7 +167,7 @@ describe('SSRController tests', () => {
     spyOn.mockRestore();
   });
 
-  it('fails to generate SSR content', async() => {
+  it('fails to generate SSR content', async (): Promise<void> => {
     const request = {
       params: {
         slug: 'test-slug'


### PR DESCRIPTION
#### What is this?
This is a fix to correct API calls that failed when run server side (inside a docker container). The calls would fail because the API_URL was set to resolve to a domain that the docker container didn't have 1) the dns records or 2) the correct certificate set up for.

My local machine might know where https://mattfinucane.build is, because I had to add my own certificate signing authority to my local keychain for development, but I can't do this so easily inside a docker container.

To get around this, all server side calls are made to `http://localhost:${port}`. Client side, the specified API_URL is used, so the whole process is seamless and easy to work with.