### PR TITLE
fix(Page): remove fixed height for page container for better scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {

--- a/src/app/views/page/Page.css.tsx
+++ b/src/app/views/page/Page.css.tsx
@@ -22,7 +22,6 @@ export const PageSt = styled.div<IPageStProps>`
   position: relative;
   display: grid;
   width: 100vw;
-  height: 100vh;
   overflow-x: hidden;
 
   grid-template-columns: 1rem auto 1rem;
@@ -60,6 +59,7 @@ export const SideSt = styled.aside<ISideStProps>`
   right: 0;
   width: 100vw;
   height: 100vh;
+  padding: 3rem 4rem;
   background: ${props => props?.theme?.colours?.secondary};
   box-shadow: none;
   transition: transform 0.5s ${animationCurve};
@@ -74,20 +74,10 @@ export const SideSt = styled.aside<ISideStProps>`
     position: unset;
     width: unset;
     height: unset;
+    padding: 0 2rem;
     grid-area: side;
     transform: unset;
     background: transparent;
-  `)};
-`;
-
-export const SideContainerSt = styled.div`
-  padding: 3rem 4rem;
-
-  ${media.md(css`
-    padding: 0 2rem;
-    position: sticky;
-    top: 0;
-    left: 0;
   `)};
 `;
 

--- a/src/app/views/page/Page.tsx
+++ b/src/app/views/page/Page.tsx
@@ -76,14 +76,12 @@ const Page = ({
       <BurgerSt navRevealed={showMenu} onClick={toggleMenu} />
       <PageSt navRevealed={showMenu}>
         <SideSt revealed={showMenu} onClick={hideMenu}>
-          <SideContainerSt>
-            <Nav />
-            <ToggleSt
-              data-testid="toggle"
-              value={currentTheme === ThemeType.DAY ? ToggleValue.OFF : ToggleValue.ON}
-              onToggle={toggleTheme}
-            />
-          </SideContainerSt>
+          <Nav />
+          <ToggleSt
+            data-testid="toggle"
+            value={currentTheme === ThemeType.DAY ? ToggleValue.OFF : ToggleValue.ON}
+            onToggle={toggleTheme}
+          />
         </SideSt>
         {
           pending ? (


### PR DESCRIPTION
#### What is this?
This is an adjustment to the styling for the main section in the page component. The styling for the height has been removed, and now scrolling on iOS devices is much smoother and less prone to locking up.