### PR TITLE
fix: correct robots.txt

### DIFF
--- a/assets/metadata/robots.txt
+++ b/assets/metadata/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -15,7 +15,7 @@ export const getConfig = (key: string, fallback: string): string | undefined => 
 
 export const config = {
   apiUrl: getConfig('API_URL', 'http://localhost:3000'),
-  cacheName: 'mattfinucane-1.0.5',
+  cacheName: 'mattfinucane-1.0.6',
   canonicalUrl: getConfig('CANONICAL_URL', 'http://localhost:3000'),
   port: getConfig('PORT', '3000'),
   enableCache: Boolean(process?.env?.ENABLE_CACHE),

--- a/src/server/controllers/AssetsController.spec.ts
+++ b/src/server/controllers/AssetsController.spec.ts
@@ -11,11 +11,12 @@ describe('AssetsController tests', (): void => {
 
     await new AssetsController();
 
-    expect(spyUse).toHaveBeenCalledTimes(5);
+    expect(spyUse).toHaveBeenCalledTimes(6);
     expect(spyUse.mock.calls[0][0]).toEqual('/docs');
     expect(spyUse.mock.calls[1][0]).toEqual('/images');
     expect(spyUse.mock.calls[2][0]).toEqual('/manifest.json');
-    expect(spyUse.mock.calls[3][0]).toEqual('/scripts');
-    expect(spyUse.mock.calls[4][0]).toEqual('/worker.js');
+    expect(spyUse.mock.calls[3][0]).toEqual('/robots.txt');
+    expect(spyUse.mock.calls[4][0]).toEqual('/scripts');
+    expect(spyUse.mock.calls[5][0]).toEqual('/worker.js');
   });
 });

--- a/src/server/controllers/AssetsController.ts
+++ b/src/server/controllers/AssetsController.ts
@@ -36,6 +36,10 @@ class AssetsController implements IBaseController {
         dir: `${this.assetsFilePath}/metadata/manifest.json`
       },
       {
+        path: '/robots.txt',
+        dir: `${this.assetsFilePath}/metadata/robots.txt`
+      },
+      {
         path: '/scripts',
         dir: `${this.distAppFilePath}/app`
       },


### PR DESCRIPTION
#### What is this?
This is a hotfix to address the missing robots.txt file. Given that it did not exist, and no route was set up for it, the html for the 404 page was being returned instead.