### PR TITLE
feat: serve generated sitemap

### DIFF
--- a/assets/metadata/sitemap.xml
+++ b/assets/metadata/sitemap.xml
@@ -1,0 +1,31 @@
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+>
+  <url>
+    <loc>https://mattfinucane.com/</loc>
+    <lastmod>2020-06-10T16:41:02+00:00</lastmod>
+    <priority>1.00</priority>
+  </url>
+  <url>
+    <loc>https://mattfinucane.com/cv</loc>
+    <lastmod>2020-06-10T16:41:02+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://mattfinucane.com/projects</loc>
+    <lastmod>2020-06-10T16:41:02+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://mattfinucane.com/now</loc>
+    <lastmod>2020-06-10T16:41:02+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://mattfinucane.com/docs/matt-finucane-cv.pdf</loc>
+    <lastmod>2020-06-10T12:47:32+00:00</lastmod>
+    <priority>0.64</priority>
+  </url>
+</urlset>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -15,7 +15,7 @@ export const getConfig = (key: string, fallback: string): string | undefined => 
 
 export const config = {
   apiUrl: getConfig('API_URL', 'http://localhost:3000'),
-  cacheName: 'mattfinucane-1.0.6',
+  cacheName: 'mattfinucane-1.0.7',
   canonicalUrl: getConfig('CANONICAL_URL', 'http://localhost:3000'),
   port: getConfig('PORT', '3000'),
   enableCache: Boolean(process?.env?.ENABLE_CACHE),

--- a/src/server/controllers/AssetsController.spec.ts
+++ b/src/server/controllers/AssetsController.spec.ts
@@ -11,12 +11,13 @@ describe('AssetsController tests', (): void => {
 
     await new AssetsController();
 
-    expect(spyUse).toHaveBeenCalledTimes(6);
+    expect(spyUse).toHaveBeenCalledTimes(7);
     expect(spyUse.mock.calls[0][0]).toEqual('/docs');
     expect(spyUse.mock.calls[1][0]).toEqual('/images');
     expect(spyUse.mock.calls[2][0]).toEqual('/manifest.json');
     expect(spyUse.mock.calls[3][0]).toEqual('/robots.txt');
-    expect(spyUse.mock.calls[4][0]).toEqual('/scripts');
-    expect(spyUse.mock.calls[5][0]).toEqual('/worker.js');
+    expect(spyUse.mock.calls[4][0]).toEqual('/sitemap.xml');
+    expect(spyUse.mock.calls[5][0]).toEqual('/scripts');
+    expect(spyUse.mock.calls[6][0]).toEqual('/worker.js');
   });
 });

--- a/src/server/controllers/AssetsController.ts
+++ b/src/server/controllers/AssetsController.ts
@@ -1,4 +1,6 @@
 import {
+  Request,
+  Response,
   Router,
   static as expressStatic,
 } from 'express';
@@ -40,6 +42,10 @@ class AssetsController implements IBaseController {
         dir: `${this.assetsFilePath}/metadata/robots.txt`
       },
       {
+        path: '/sitemap.xml',
+        dir: `${this.assetsFilePath}/metadata/sitemap.xml`
+      },
+      {
         path: '/scripts',
         dir: `${this.distAppFilePath}/app`
       },
@@ -51,7 +57,7 @@ class AssetsController implements IBaseController {
 
     routes.forEach(({ dir, path }: IRoutePair) =>
       this.router.use(path, expressStatic(dir)));
-  }
+  };
 }
 
 export default AssetsController;


### PR DESCRIPTION
#### What is this?
This PR adds a basic sitemap to the site for re-submission to search engines. A big refactoring of this is needed, so this is more of a hot-fix as opposed to a feature implementation.