### PR TITLE
feat(deploy): implement CircleCI for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,86 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: node:12.18-alpine
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore build cache
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run:
+          name: Install yarn dependencies
+          command: yarn
+      - save_cache:
+          name: Save build cache
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - run:
+          name: Run tests with coverage
+          command: yarn coverage
+      - run:
+          name: Run code lint
+          command: yarn lint
+      - run:
+          name: Run style lint
+          command: yarn csslint
+
+  build:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Build and push docker containers
+          command: |
+            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+            docker-compose -f docker-compose.yml -f docker-compose.prod.yml build
+            docker-compose push
+
+  deploy:
+    machine: true
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "69:f4:84:f0:e9:82:8a:88:4e:f2:94:a2:25:80:f1:cb"
+      - run:
+          name: Copy docker compose files to remote server
+          command: scp -r docker-compose.yml docker-compose.prod.yml .docker/ $DEPLOY_USER@$DEPLOY_HOST:~/
+      - run:
+          name: Remotely pull docker images, then restart the container
+          command: |
+            ssh -t $DEPLOY_USER@$DEPLOY_HOST "
+              docker pull matfin/personal-website-app:latest &&
+              docker pull matfin/personal-website-nginx:latest &&
+              docker stop app nginx &&
+              docker rm app nginx &&
+              docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+            "
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - test:
+          filters:
+            branches:
+              ignore: master
+      - build:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,6 @@ node_modules
 *.log
 **/*.spec.tsx
 **/*.spec.ts
+.vscode
+docker-compose*
+webpack.dev.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     environment:
       - API_URL=https://mattfinucane.build
       - CANONICAL_URL=https://mattfinucane.build
-      - PORT=3001
       - ENABLE_CACHE=true
+      - NODE_ENV-production
+      - PORT=3001
     command: yarn prodserver
 
   nginx:

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.0.7",
+  "version": "1.0.11",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {
+    "checks": "yarn coverage && yarn lint && yarn csslint",
     "server": "node-dev ./dist/server/server.js",
     "prodserver": "node ./dist/server/server.js",
     "dev": "webpack --config webpack.dev.js --watch --progress --colors --open",
@@ -104,8 +105,6 @@
     }
   },
   "pre-commit": [
-    "coverage",
-    "lint",
-    "csslint"
+    "checks"
   ]
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -15,7 +15,7 @@ export const getConfig = (key: string, fallback: string): string | undefined => 
 
 export const config = {
   apiUrl: getConfig('API_URL', 'http://localhost:3000'),
-  cacheName: 'mattfinucane-1.0.7',
+  cacheName: 'mattfinucane-1.0.11',
   canonicalUrl: getConfig('CANONICAL_URL', 'http://localhost:3000'),
   port: getConfig('PORT', '3000'),
   enableCache: Boolean(process?.env?.ENABLE_CACHE),


### PR DESCRIPTION
#### What is this?
This PR sets up continuous deployment / integration with CircleCI. The process for pushing updates will now be as follows:

##### On my local dev machine
- Bump the version number in `package.json` and `common/config.ts`
- run `$ yarn checks` which will do the following:
    - run test coverage
    - code lint
    - style lint
- squash the commit into a single one
- push changes to the branch

##### On CircleCI (when not on the master branch)
- check out the latest project from GitHub (hooks are already set up)
- install node dependencies with `$ yarn`
- save node_modules to a cache (the key being the checksum of package.json)
- run all tests with coverage
- run code lint
- run css lint
- assuming all was good, GitHub will be notified and the PR for the branch can be merged.
- if any of the above steps fail, then the PR for the branch cannot be merged.

###### On CircleCI when on the master branch
- check out the latest project from GitHub
- log in to Docker Hub
- build the production Docker images, then push them to Docker Hub tagged with :latest
- start deployment by kicking off a new workflow job
- set up ssh keys, because we need to ssh into our production server in one of the steps
- copy over the docker compose files and Dockerfiles, plus other supporting items like configs
- ssh into the remote server, then issue a command to pull the latest images
- stop the current containers from running
- start the containers again with docker compose and those latest images we pulled
- the new site should now be running