### PR TITLE
fix(CircleCI): correct workflow branch config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,17 +70,13 @@ workflows:
             branches:
               ignore: master
       - build:
-          requires:
-            - test
           filters:
             branches:
-              only:
-                - master
+              only: master
       - deploy:
           requires:
             - build
           filters:
             branches:
-              only:
-                - master
+              only: master
 


### PR DESCRIPTION
#### What is this?
This is a hot fix to ensure that the workflows (build, deploy) in CircleCI that are associated solely with the master branch are run when a merge to master happens.