### PR TITLE
feat: activate menu on touch for touch devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {

--- a/src/app/components/menubutton/MenuButton.spec.tsx
+++ b/src/app/components/menubutton/MenuButton.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 import { fireEvent, render } from '@testing-library/react';
+import * as utils from 'common/utils/utils';
 import { MenuButton, IProps } from './MenuButton';
 
 const defaultProps: IProps = {
@@ -16,6 +17,7 @@ describe('MenuButton tests', () => {
   });
 
   it('executes the callback on click', () => {
+    const spyIsTouchDevice = jest.spyOn(utils, 'isTouchDevice').mockReturnValue(false);
     const spyOnClick = jest.fn();
     const wrapper = render(
       <MenuButton
@@ -26,7 +28,30 @@ describe('MenuButton tests', () => {
     const button = wrapper.getByTestId('menubutton');
 
     fireEvent.click(button);
-    expect(spyOnClick).toHaveBeenCalled();
+    fireEvent.touchStart(button);
+
+    expect(spyOnClick).toHaveBeenCalledTimes(1);
+
+    spyIsTouchDevice.mockRestore();
+  });
+
+  it('executes the callback on touch', () => {
+    const spyIsTouchDevice = jest.spyOn(utils, 'isTouchDevice').mockReturnValue(true);
+    const spyOnClick = jest.fn();
+    const wrapper = render(
+      <MenuButton
+        {...defaultProps}
+        onClick={spyOnClick}
+      />,
+    );
+    const button = wrapper.getByTestId('menubutton');
+
+    fireEvent.click(button);
+    fireEvent.touchStart(button);
+
+    expect(spyOnClick).toHaveBeenCalledTimes(1);
+
+    spyIsTouchDevice.mockRestore();
   });
 
   it('has the correct style when revealed', async () => {

--- a/src/app/components/menubutton/MenuButton.tsx
+++ b/src/app/components/menubutton/MenuButton.tsx
@@ -1,16 +1,27 @@
 import React from 'react';
+import { isTouchDevice } from 'common/utils';
 import { LinePlacement, LineSt, MenuButtonSt } from './MenuButton.css';
 
 export interface IProps {
   className?: string,
   navRevealed: boolean,
-  onClick(): void,
+  onClick(e: React.MouseEvent | React.TouchEvent): void,
 }
 
-export const MenuButton = ({ className, onClick, navRevealed }: IProps): JSX.Element => (
-  <MenuButtonSt aria-label="Menu" data-testid="menubutton" className={className} onClick={onClick}>
-    <LineSt placement={LinePlacement.TOP} revealed={navRevealed} />
-    <LineSt placement={LinePlacement.MIDDLE} revealed={navRevealed} />
-    <LineSt placement={LinePlacement.BOTTOM} revealed={navRevealed} />
-  </MenuButtonSt>
-);
+export const MenuButton = ({ className, onClick, navRevealed }: IProps): JSX.Element => {
+  const shouldUseTouch: boolean = isTouchDevice();
+
+  return (
+    <MenuButtonSt
+      aria-label="Menu"
+      data-testid="menubutton"
+      className={className}
+      onClick={!shouldUseTouch ? onClick : (): void => {}}
+      onTouchStart={shouldUseTouch ? onClick : (): void => {}}
+    >
+      <LineSt placement={LinePlacement.TOP} revealed={navRevealed} />
+      <LineSt placement={LinePlacement.MIDDLE} revealed={navRevealed} />
+      <LineSt placement={LinePlacement.BOTTOM} revealed={navRevealed} />
+    </MenuButtonSt>
+  );
+};

--- a/src/app/styles/global.ts
+++ b/src/app/styles/global.ts
@@ -27,6 +27,7 @@ export const GlobalStyle = createGlobalStyle`
   button {
     border: none;
     background-color: inherit;
+    -webkit-tap-highlight-color: transparent;
 
     &:focus {
       outline: 0;

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -15,7 +15,7 @@ export const getConfig = (key: string, fallback: string): string | undefined => 
 
 export const config = {
   apiUrl: getConfig('API_URL', 'http://localhost:3000'),
-  cacheName: 'mattfinucane-1.0.11',
+  cacheName: 'mattfinucane-1.0.12',
   canonicalUrl: getConfig('CANONICAL_URL', 'http://localhost:3000'),
   port: getConfig('PORT', '3000'),
   enableCache: Boolean(process?.env?.ENABLE_CACHE),

--- a/src/common/utils/utils.spec.ts
+++ b/src/common/utils/utils.spec.ts
@@ -2,6 +2,7 @@ import {
   formatDate,
   isExternalUrl,
   isLink,
+  isTouchDevice,
   toLinkObject,
   splitContent,
 } from './utils';
@@ -73,5 +74,14 @@ describe('utils tests', (): void => {
       '[another one](/another)',
       ' right here!',
     ]);
+  });
+
+  it('checks for touch devices', () => {
+    expect(isTouchDevice()).toBe(false);
+
+    global.ontouchstart = () => {};
+    expect(isTouchDevice()).toBe(true);
+
+    global.ontouchstart = undefined;
   });
 });

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -66,3 +66,7 @@ export const splitContent = (text: string): string[] => {
 };
 
 export const isServer = (): boolean => typeof window === 'undefined';
+
+export const isTouchDevice = (): boolean => (
+  typeof window !== 'undefined' && 'ontouchstart' in window
+);


### PR DESCRIPTION
#### What is this?
This PR adds a `touchstart` event for touch based devices, to make tapping the menu more responsive. For non-touch devices, `onClick` remains as the event to trigger show / hide for the menu.

The menu button no longer blinks when tapped on Safari for iOS devices.