### PR TITLE
fix: build process should only happen for main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,15 @@ workflows:
       - test:
           filters:
             branches:
-              ignore: master
+              ignore: main
       - build:
           filters:
             branches:
-              only: master
+              only: main
       - deploy:
           requires:
             - build
           filters:
             branches:
-              only: master
+              only: main
 


### PR DESCRIPTION
#### What is this?
This is a small PR to fix deployments, so that they are triggered correctly when a PR is merged into the 'main' branch. This was set up before to work on the 'master' branch, but the master branch is now defunct.