### PR TITLE
feat: correct text content and add back button for projects

### DIFF
--- a/assets/pages/about.json
+++ b/assets/pages/about.json
@@ -121,7 +121,7 @@
             {
               "tagName": "li",
               "id": "tenet-2",
-              "content": "Premature optimisation is the root of all evil. If you devise a solution for too many hypotehtical situations, you will end up with something that could easily be going in the wrong direction, and it will be difficult to correct at a later date."
+              "content": "Premature optimisation is the root of all evil. If you devise a solution for too many hypothetical situations, you will end up with something that could easily be going in the wrong direction, and it will be difficult to correct at a later date."
             },
             {
               "tagName": "li",
@@ -146,17 +146,17 @@
             {
               "tagName": "li",
               "id": "tenet-6",
-              "content": "Always help those around you and don't hesitate to ask for help yourself. It is quite often the case when you encounter a problem, that when you start explaining it to someone else, the solution comes into your head almost immediately afterward. Sharing facilitates good team chemistry. If someone comes looking for help and they can't find who they are looking for, offer your own help."
+              "content": "Always help those around you and don't hesitate to ask for help yourself. It is quite often the case when you encounter a problem, that when you start explaining it to someone else, the solution comes into your head almost immediately afterwards. Sharing facilitates good team chemistry. If someone comes looking for help and they can't find who they are looking for, offer your own help."
             },
             {
               "tagName": "li",
               "id": "tenet-7",
-              "content": "Always listen to what your peers have to say and give them an equal footing - junior engineers especially. They can provide insights you may have never thought of, and junior does not necessarily mean less capable. Exposing junior engineers to tasks those more senior can be a good thing to do, as long as they are comfortable with doing this. Again, their insights can be very useful."
+              "content": "Always listen to what your peers have to say and give them an equal footing - junior engineers especially. They can provide insights you may have never thought of, and junior does not necessarily mean less capable. Exposing junior engineers to tasks those more senior can be a good thing to do, as long as they are comfortable doing this. Again, their insights can be very useful."
             },
             {
               "tagName": "li",
               "id": "tenet-8",
-              "content": "Good hardware is essential. You should have the best hardware money can buy (within reason). Slow and inadequete hardware with cramped keyboards and tiny screens can have a serious impact on build times and overall productivity. Those extra minutes to add up."
+              "content": "Good hardware is essential. You should have the best hardware money can buy (within reason). Slow and inadequate hardware with cramped keyboards and tiny screens can have a serious impact on build times and overall productivity. Those extra minutes to add up."
             }
           ]
         }

--- a/assets/pages/cv.json
+++ b/assets/pages/cv.json
@@ -108,7 +108,7 @@
               "role": "Senior full-stack engineer (contract)",
               "startDate": "2013-03-12",
               "tasks": [
-                "Created a knowledge based information portal (secure document sharing, retrieval and storage) for a large telecomms organisation in PHP.",
+                "Created a knowledge based information portal (secure document sharing, retrieval and storage) for a large telecoms organisation in PHP.",
                 "Optimised customer login/registration flow and integrated this with other CRM tools (Salesforce, Eloqua).",
                 "Integrated the Compass SCSS framework and optimised HTML templates to improve SEO performance.",
                 "Developed HTML templates for the internal corporate IT intranet and assisted in integrating them to Microsoft Sharepoint."
@@ -154,7 +154,7 @@
                 "Created several bespoke content managed websites for clients using hand-coded html and php.",
                 "Leveraged Twitter and Facebook APIs, to optimise the clients’ online offering.",
                 "Provided web content strategy guidance to clients.",
-                "Practiced excellent standards in web development to ensure organic SEO performance and accessibility.",
+                "Practised excellent standards in web development to ensure organic SEO performance and accessibility.",
                 "Initiated, managed and maintained long-lasting professional client relationships."
               ],
               "topics": []
@@ -169,7 +169,7 @@
                 "Redeveloped the HTML and CSS during a complete overhaul of the company website.",
                 "Created an internal WYSIWYG tool to author promotional emails and newsletter templates.",
                 "Designed and built the in house intranet portal, tying it into existing LDAP servers. This enabled seamless integration with existing user logins.",
-                "Provided ongoing maintenance to website product pages to optimise the eCommerce purchase flows."
+                "Provided ongoing maintenance to website product pages to optimise the e-commerce purchase flows."
               ],
               "topics": []
             },

--- a/assets/pages/projects.json
+++ b/assets/pages/projects.json
@@ -52,7 +52,7 @@
             {
               "description": "User community website for StackPointCloud (Kubernetes).",
               "slug": "spc-community",
-              "title": "StackPointCloud Community"
+              "title": "SPC Community"
             },
             {
               "description": "An Open-source package to leverage content management in MeteorJS applications.",

--- a/assets/pages/projects/spc-community.json
+++ b/assets/pages/projects/spc-community.json
@@ -10,7 +10,7 @@
         {
           "id": "spc-1",
           "tagName": "h1",
-          "content": "StackPointCloud Community"
+          "content": "SPC Community"
         },
         {
           "id": "spc-2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {

--- a/src/app/components/menubutton/MenuButton.css.tsx
+++ b/src/app/components/menubutton/MenuButton.css.tsx
@@ -16,7 +16,7 @@ const transformTo = (placement: LinePlacement): FlattenSimpleInterpolation => {
   switch (placement) {
     case LinePlacement.TOP: {
       return css`
-        transform: translate3d(0, 10px, 0) rotate(-45deg);
+        transform: translate3d(0, 12px, 0) rotate(-45deg);
       `;
     }
     case LinePlacement.BOTTOM: {

--- a/src/app/components/menubutton/MenuButton.spec.tsx
+++ b/src/app/components/menubutton/MenuButton.spec.tsx
@@ -56,7 +56,7 @@ describe('MenuButton tests', () => {
 
     expect(lines[0]).toHaveStyleRule(
       'transform',
-      'translate3d(0,10px,0) rotate(-45deg)'
+      'translate3d(0,12px,0) rotate(-45deg)'
     );
     expect(lines[1]).toHaveStyleRule('transform', 'rotate(135deg)');
     expect(lines[2]).toHaveStyleRule(

--- a/src/app/views/page/Page.css.tsx
+++ b/src/app/views/page/Page.css.tsx
@@ -1,11 +1,22 @@
 import styled, { css } from 'styled-components';
-import { animationCurve, boxShadow, layers, media } from 'app/styles';
+import { Link } from 'react-router-dom';
+import {
+  animationCurve,
+  boxShadow,
+  layers,
+  media,
+  textTypography,
+} from 'app/styles';
 import { Footer } from 'app/components/footer/Footer';
 import { Loading } from 'app/components/loading/Loading';
 import { MenuButton } from 'app/components/menubutton/MenuButton';
 
 interface ISideStProps {
   revealed: boolean;
+}
+
+interface IMainStProps {
+  nested: boolean;
 }
 
 interface IPageStProps {
@@ -50,7 +61,8 @@ export const PageSt = styled.div<IPageStProps>`
   `)}
 `;
 
-export const MainSt = styled.main`
+export const MainSt = styled.main<IMainStProps>`
+  position: relative;
   grid-area: main;
   border: 0.125rem solid ${(props) => props?.theme?.colours?.primary};
   padding: 0.75rem;
@@ -58,6 +70,16 @@ export const MainSt = styled.main`
   ${media.md(css`
     padding: 1.75rem;
   `)}
+
+  ${({ nested }) =>
+    nested &&
+    css`
+      padding-top: 3rem;
+
+      ${media.md(css`
+        padding-top: 4rem;
+      `)}
+    `}
 `;
 
 export const SideSt = styled.aside<ISideStProps>`
@@ -105,6 +127,27 @@ export const BurgerSt = styled(MenuButton)`
   ${media.md(css`
     display: none;
   `)}
+`;
+
+export const BackSt = styled(Link)`
+  position: absolute;
+  top: -1.25rem;
+  left: -0.125rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  border: 0.125rem solid ${(props) => props?.theme?.colours?.primary};
+  background: ${(props) => props?.theme?.colours?.secondary};
+  ${textTypography}
+
+  &::before {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    content: '<';
+    font-size: 1.5rem;
+  }
 `;
 
 export const ErrorSt = styled.div`

--- a/src/app/views/page/Page.tsx
+++ b/src/app/views/page/Page.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Meta } from 'app/components/meta/Meta';
-import { setBodyOverflow } from 'common/utils';
+import { pathNesting, setBodyOverflow } from 'common/utils';
 import { IContentItem, IPage, ToggleValue, ThemeType } from 'common/interfaces';
 import { ContentItem } from 'app/components/contentItem/ContentItem';
 import { Nav } from 'app/components/nav/Nav';
 import { Toggle } from 'app/components/toggle/Toggle';
 import {
+  BackSt,
   BurgerSt,
   ErrorSt,
   FooterSt,
@@ -35,6 +36,10 @@ const errorMessage = (error: any): JSX.Element => (
   <ErrorSt>{error.toString()}</ErrorSt>
 );
 
+const backButton = (href: string): JSX.Element => (
+  <BackSt arial-label="back" data-testid="backbutton" to={href} />
+);
+
 const Page = ({
   currentTheme,
   error,
@@ -45,8 +50,8 @@ const Page = ({
   switchTheme,
 }: IProps): JSX.Element => {
   const { pathname } = useLocation();
+  const { isNested, parts } = pathNesting(pathname);
   const [showMenu, setShowMenu] = useState<boolean>(false);
-
   const toggleMenu = (): void => {
     setShowMenu(!showMenu);
     setBodyOverflow(!!showMenu);
@@ -106,7 +111,12 @@ const Page = ({
               title={page?.title}
               slug={page?.slug}
             />
-            <MainSt aria-label="Main content" onClick={hideMenu}>
+            <MainSt
+              nested={isNested}
+              aria-label="Main content"
+              onClick={hideMenu}
+            >
+              {isNested && backButton(`/${parts[0]}`)}
               {!pending && error && errorMessage(error)}
               {!pending && page && pageContents(page)}
             </MainSt>

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -17,7 +17,7 @@ export const getConfig = (
 
 export const config = {
   apiUrl: getConfig('API_URL', 'http://localhost:3000'),
-  cacheName: 'mattfinucane-1.1.2',
+  cacheName: 'mattfinucane-1.1.3',
   canonicalUrl: getConfig('CANONICAL_URL', 'http://localhost:3000'),
   port: getConfig('PORT', '3000'),
   enableCache: Boolean(process?.env?.ENABLE_CACHE),

--- a/src/common/interfaces/models.ts
+++ b/src/common/interfaces/models.ts
@@ -75,3 +75,8 @@ export interface IProject {
 export interface CacheDictionary {
   [index: string]: string;
 }
+
+export interface IPathNesting {
+  isNested: boolean;
+  parts: string[];
+}

--- a/src/common/utils/utils.spec.ts
+++ b/src/common/utils/utils.spec.ts
@@ -4,6 +4,7 @@ import {
   isIE,
   isLink,
   isTouchDevice,
+  pathNesting,
   toLinkObject,
   splitContent,
 } from './utils';
@@ -31,7 +32,7 @@ describe('utils tests', (): void => {
     );
   });
 
-  it('checks to see if a url is external', () => {
+  it('checks to see if a url is external', (): void => {
     expect(isExternalUrl('https://www.test.de')).toBe(true);
     expect(isExternalUrl('http://www.test.de')).toBe(true);
     expect(isExternalUrl('/test-content')).toBe(false);
@@ -75,7 +76,7 @@ describe('utils tests', (): void => {
     ]);
   });
 
-  it('checks for touch devices', () => {
+  it('checks for touch devices', (): void => {
     expect(isTouchDevice()).toBe(false);
 
     global.ontouchstart = () => {};
@@ -84,7 +85,7 @@ describe('utils tests', (): void => {
     global.ontouchstart = undefined;
   });
 
-  it('checks the user agent string for IE', () => {
+  it('checks the user agent string for IE', (): void => {
     expect(
       isIE(
         'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko'
@@ -102,5 +103,27 @@ describe('utils tests', (): void => {
     ).toBe(false);
 
     expect(isIE()).toBe(false);
+  });
+
+  it('returns the correct path nesting', (): void => {
+    expect(pathNesting('/projects/test')).toEqual({
+      isNested: true,
+      parts: ['projects', 'test'],
+    });
+
+    expect(pathNesting('/projects')).toEqual({
+      isNested: false,
+      parts: ['projects'],
+    });
+
+    expect(pathNesting('')).toEqual({
+      isNested: false,
+      parts: [],
+    });
+
+    expect(pathNesting()).toEqual({
+      isNested: false,
+      parts: [],
+    });
   });
 });

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -1,4 +1,4 @@
-import { ILink } from 'common/interfaces';
+import { ILink, IPathNesting } from 'common/interfaces';
 
 const months: string[] = [
   'January',
@@ -36,6 +36,17 @@ export const isExternalUrl = (url: string): boolean => {
   const regexp: RegExp = /(https?:\/\/|mailto:)/;
 
   return regexp.test(url);
+};
+
+export const pathNesting = (pathname: string = ''): IPathNesting => {
+  const parts = pathname.split('/');
+
+  parts.shift();
+
+  return {
+    parts,
+    isNested: parts.length > 1,
+  };
 };
 
 export const toLinkObject = (linkText: string): ILink => {


### PR DESCRIPTION
#### What is this?
This PR contains some content fixes as follows:
- minor spelling errors caught and corrected
- back button added for pages that are nested, for example /projects/test
- corrected the StackPointCloud project content, which was pushing the content width too far wide on mobile
