### PR TITLE
fix: improve types for fetchPage redux thunk action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Personal website built using React and TypeScript",
   "main": "src/index.js",
   "scripts": {

--- a/src/app/views/page/ConnectedPage.tsx
+++ b/src/app/views/page/ConnectedPage.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { AppDispatch, CombinedAppState, ThemeType } from 'common/models';
+import { CombinedAppState, ThemeType } from 'common/models';
 import { switchTheme } from 'app/actions';
-import { fetchPage, resetPage } from './actions';
+import { fetchPage, FetchPageDispatch, resetPage } from './actions';
 import Page, { Props } from './Page';
+
+interface MapDispatchToProps {
+  fetchPage: (slug: string) => void;
+  resetPage: () => void;
+  switchTheme: (theme: ThemeType) => void;
+}
 
 const mapStateToProps = (state: CombinedAppState) => ({
   currentTheme: state.appState.currentTheme,
@@ -12,7 +18,9 @@ const mapStateToProps = (state: CombinedAppState) => ({
   page: state.pageState.page,
 });
 
-export const mapDispatchToProps = (dispatch: AppDispatch): unknown => ({
+export const mapDispatchToProps = (
+  dispatch: FetchPageDispatch
+): MapDispatchToProps => ({
   fetchPage: (slug: string): void => {
     dispatch(fetchPage(slug));
   },

--- a/src/app/views/page/actions.spec.ts
+++ b/src/app/views/page/actions.spec.ts
@@ -38,7 +38,7 @@ describe('page actions tests', () => {
   });
 
   it('returns the correct type on fetch page failure', () => {
-    const error = { dummy: 'error' };
+    const error = new Error('error');
 
     expect(fetchPageFailure(error)).toEqual({
       type: ActionTypes.FETCH_PAGE_FAILURE,

--- a/src/app/views/page/actions.ts
+++ b/src/app/views/page/actions.ts
@@ -1,6 +1,8 @@
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { Action } from 'redux';
 import { Response } from 'node-fetch';
 import { apiCall } from 'common/utils';
-import { AppDispatch, AppThunk, PageProps } from 'common/models';
+import { PageReducerState, PageProps } from 'common/models';
 import ActionTypes from './types';
 
 /**
@@ -33,6 +35,18 @@ export type PageActionTypes =
   | FetchPageFailure
   | ResetPage;
 
+export type FetchPageThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  PageReducerState,
+  void,
+  Action<string>
+>;
+export type FetchPageDispatch = ThunkDispatch<
+  PageReducerState,
+  void,
+  Action<string>
+>;
+
 /**
  * Exported actions
  */
@@ -54,9 +68,9 @@ export const resetPage = (): PageActionTypes => ({
   type: ActionTypes.RESET_PAGE,
 });
 
-export const fetchPage = (slug: string): AppThunk<Promise<void>> => async (
-  dispatch: AppDispatch
-) => {
+export const fetchPage = (slug: string): FetchPageThunk => async (
+  dispatch: FetchPageDispatch
+): Promise<void> => {
   const pageRequestTimeout: number = setTimeout(
     (): PageActionTypes => dispatch(fetchPageRequest()),
     200

--- a/src/common/models/types.ts
+++ b/src/common/models/types.ts
@@ -1,7 +1,4 @@
-import { Action } from 'redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import {
-  CombinedAppState,
   ContentItemProps,
   ImageProps,
   PositionProps,
@@ -60,16 +57,3 @@ export type Orientations = {
 };
 
 export type JSXChildren = string | JSX.Element | JSX.Element[];
-
-export type AppThunk<ReturnType = void> = ThunkAction<
-  ReturnType,
-  CombinedAppState,
-  void,
-  Action<string>
->;
-
-export type AppDispatch = ThunkDispatch<
-  CombinedAppState,
-  unknown,
-  Action<string>
->;


### PR DESCRIPTION
#### What is this?
This PR improves type safety for the thunk action to fetch a page. I have removed the generic Thunk and Dispatch type from the main models/ and put them inside the page actions, where they can be better typed. No more use of :any or :unknown and the connected page component now has better typing.