### PR TITLE
feat: re-enable csp and service worker for PWA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Bundle JS and build static content
-          command: CANONICAL_URL=https://mattfinucane.com yarn deploy
+          command: ENABLE_CACHE='true' CANONICAL_URL=https://mattfinucane.com yarn deploy
       - run:
           name: Create archive of built content
           command: tar czf out.tar.gz dist

--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 CANONICAL_URL=http://localhost:3000
 CONTENT_BASE=./public/pages
+ENABLE_CACHE=true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,10 +13,12 @@ This is what we need to do to build a nice, simple, well maintained application.
 - animated UI to communicate flow effectively to the user
 - production bundling and CI flow
 - use Redux ToolKit
+- progressive web app with offline capability
+- Content security policy
 
 ## Nice to have
 
 - use Storybook for component rendering/documentation
+- remove barrel imports to improve build and test performance
 - error boundary for better error handling
-- progressive web app with offline capability
 - md file describing the architectural overview, which needs to be rewritten

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       dockerfile: .docker/node/Dockerfile
       args:
         - CANONICAL_URL=https://mattfinucane.build
+        - ENABLE_CACHE='true'
     volumes:
       - static-content:/opt/app/dist
     command: yarn deploy

--- a/index.html
+++ b/index.html
@@ -2,12 +2,14 @@
 <html lang="en-IE">
   <head>
     <meta charset="UTF-8" />
+    <!--contentsecurity-->
     <meta name="author" content="Matt Finucane" />
     <meta property="og:site_name" content="mattfinucane.com" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en-IE" />
     <meta name="twitter:site" content="@matfinucane" />
     <meta name="twitter:creator" content="@matfinucane" />
+    <link rel="manifest" href="/manifest.json" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -60,5 +62,6 @@
     <div id="root"><!--root-content--></div>
     <script type="module" src="/src/entry-client.tsx"></script>
     <!--preloadedstate-->
+    <!--swregister-->
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattfinucane.com",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Personal website built using React and TypeScript",
   "type": "module",
   "scripts": {

--- a/prerender.ts
+++ b/prerender.ts
@@ -6,12 +6,16 @@ import ContentRenderer from '@ssg/ContentRenderer';
   const config: Record<string, string | undefined> = {
     contentBase: process.env.CONTENT_BASE,
     canonicalUrl: process.env.CANONICAL_URL,
+    enableCache: process.env.ENABLE_CACHE,
   };
   const slugs: string[] | null = await ContentLoader.generateSlugs(
     toAbsolute(config.contentBase ?? './public/pages'),
   );
 
-  await ContentRenderer.generateStaticHTML(slugs ?? []);
+  await ContentRenderer.generateStaticHTML(
+    slugs ?? [],
+    config.enableCache === 'true',
+  );
   await ContentRenderer.generateXMLSitemap(
     slugs ?? [],
     config.canonicalUrl ?? '',

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,53 @@
+{
+  "name": "Matt Finucane - Portfolio",
+  "short_name": "Matt Finucane",
+  "description": "Personal website built using React and TypeScript",
+  "icons": [
+    {
+      "src": "/images/icons/logo-48.png",
+      "sizes": "48x48",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/logo-72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/logo-96.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/logo-144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/logo-168.png",
+      "sizes": "168x168",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/logo-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/logo-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/icons/maskable-icon.png",
+      "sizes": "196x196",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#ecedef",
+  "theme_color": "#ecedef"
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,3 @@
-const appIconSizes: number[] = [32, 48, 72, 96, 128, 144, 168, 192, 196, 512];
-
-export const getAppIconSizes = (): number[] => appIconSizes;
 export const getCanonicalUrl = (): string => CANONICAL_URL;
 export const getContentBase = (): string => CONTENT_BASE;
+export const getCacheName = (): string => PWA_CACHE_NAME;

--- a/src/swregister.ts
+++ b/src/swregister.ts
@@ -1,0 +1,17 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', (): void => {
+    navigator.serviceWorker
+      .register('/worker.js')
+      .then(
+        (registration) => {
+          console.log('Worker registration succeeded', registration.scope);
+        },
+        (error) => {
+          throw new Error(error);
+        },
+      )
+      .catch((error) => {
+        console.log('Worker registration failed', error);
+      });
+  });
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,4 @@
 
 declare const CANONICAL_URL: string;
 declare const CONTENT_BASE: string;
+declare const PWA_CACHE_NAME: string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,84 @@
+const appIconSizes: number[] = [32, 48, 72, 96, 128, 144, 168, 192, 196, 512];
+const cacheName: string = PWA_CACHE_NAME;
+const appIconPaths: string[] = appIconSizes.map(
+  (size: number) => `/images/icons/logo-${size}.png`,
+);
+const profilePicPaths: string[] = [
+  '/images/profile-lg@1x.jpg',
+  '/images/profile-lg@1x.webp',
+  '/images/profile-lg@2x.jpg',
+  '/images/profile-lg@2x.webp',
+  '/images/profile-lg@3x.jpg',
+  '/images/profile-lg@3x.webp',
+  '/images/profile-sm@1x.jpg',
+  '/images/profile-sm@1x.webp',
+  '/images/profile-sm@2x.jpg',
+  '/images/profile-sm@2x.webp',
+  '/images/profile-sm@3x.jpg',
+  '/images/profile-sm@3x.webp',
+];
+const assetUrls: string[] = [
+  '/manifest.json',
+  '/pwa.json',
+  '/main.js',
+  '/worker.js',
+  '/swregister.js',
+  ...appIconPaths,
+  ...profilePicPaths,
+];
+
+const generatePaths = async (): Promise<string[]> => {
+  const response: Response = await fetch('/pwa.json');
+  const paths: string[] = await response.json();
+
+  return paths;
+};
+
+const onActivate = (event: ExtendableEvent): void => {
+  const cacheWhitelist = [cacheName];
+  const clearCaches = (): Promise<void | boolean[]> =>
+    caches.keys().then((cacheNames: string[]) =>
+      Promise.all(
+        cacheNames.map((name: string): Promise<boolean> => {
+          if (!cacheWhitelist.includes(name)) {
+            return caches.delete(name);
+          }
+          return Promise.resolve(false);
+        }),
+      ),
+    );
+
+  event.waitUntil([clearCaches()]);
+};
+
+const onInstall = (event: ExtendableEvent): void => {
+  const preCache = async (): Promise<void> => {
+    const cache: Cache = await caches.open(cacheName);
+    const paths: string[] = await generatePaths();
+    const items: string[] = [
+      ...assetUrls,
+      ...paths.map((path: string): string => `/pages/${path}.json`),
+      ...paths.map(
+        (path: string): string => `${path === 'index' ? '/' : `${path}/`}`,
+      ),
+    ];
+
+    return cache.addAll(items);
+  };
+
+  event.waitUntil(preCache());
+};
+
+const onFetch = (event: FetchEvent): void => {
+  event.respondWith(
+    caches
+      .match(event.request)
+      .then(
+        (response: Response | undefined) => response ?? fetch(event.request),
+      ),
+  );
+};
+
+self.addEventListener('activate', onActivate);
+self.addEventListener('fetch', onFetch);
+self.addEventListener('install', onInstall);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     },
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["WebWorker", "ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["WebWorker", "ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,23 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 import tsconfigpaths from 'vite-tsconfig-paths';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ isSsrBuild }) => {
   return {
     plugins: [tsconfigpaths(), react()],
+    build: {
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'index.html'),
+          worker: resolve(__dirname, 'src/worker.ts'),
+          swregister: resolve(__dirname, 'src/swregister.ts'),
+        },
+        output: {
+          entryFileNames: '[name].js',
+        },
+      },
+    },
     ssr: {
       noExternal: ['react-helmet-async', 'styled-components'],
     },
@@ -13,6 +26,9 @@ export default defineConfig(({ isSsrBuild }) => {
         process.env.CANONICAL_URL ?? 'http://localhost:3000',
       ),
       CONTENT_BASE: JSON.stringify('./pages'),
+      PWA_CACHE_NAME: JSON.stringify(
+        `${process.env.npm_package_name}:${process.env.npm_package_version}`,
+      ),
     },
     publicDir: isSsrBuild ? false : 'public',
     test: {


### PR DESCRIPTION
**What is this?**

This PR reinstates the CSP meta tags and PWA offline capabilities.

- The pre-render script injects the CSP meta tags for non-dev mode and generates a random UUID for inline scripts.
- The worker script has been reinstated alongside a new script to register it.
- CSP and PWA capability does not work in dev mode.
- Rollup options have been added to the vite configuration to generate the output bundles for main, worker and worker registration.